### PR TITLE
Move inspection to external_annotator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased]
+- Move inspection to external_annotator [[#158](https://github.com/koxudaxi/ruff-pycharm-plugin/pull/158)]
 
 ## [0.0.13] - 2023-04-25
 - Add disableOnSaveOutsideOfProject option [[#155](https://github.com/koxudaxi/ruff-pycharm-plugin/pull/155)]

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ pluginGroup = com.koxudaxi.ruff
 pluginName = Ruff
 pluginRepositoryUrl = https://github.com/koxudaxi/ruff-pycharm-plugin
 # SemVer format -> https://semver.org
-pluginVersion = 0.0.13
+pluginVersion = 0.0.14
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 222

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -13,10 +13,10 @@
         <projectConfigurable groupId="tools" instance="com.koxudaxi.ruff.RuffConfigurable"/>
         <postFormatProcessor
                 implementation="com.koxudaxi.ruff.RuffPostFormatProcessor"/>
-<!--        <localInspection language="Python" shortName="RuffInspection" suppressId="Ruff"-->
-<!--                         displayName="Ruff inspection"-->
-<!--                         enabledByDefault="true" level="WARNING"-->
-<!--                         implementationClass="com.koxudaxi.ruff.RuffInspection"/>-->
+        <localInspection language="Python" shortName="RuffInspection" suppressId="Ruff"
+                         displayName="Ruff inspection"
+                         enabledByDefault="true" level="WARNING"
+                         implementationClass="com.koxudaxi.ruff.RuffInspection"/>
         <externalAnnotator language="Python" implementationClass="com.koxudaxi.ruff.RuffExternalAnnotator"/>
     </extensions>
     <projectListeners>

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -13,10 +13,11 @@
         <projectConfigurable groupId="tools" instance="com.koxudaxi.ruff.RuffConfigurable"/>
         <postFormatProcessor
                 implementation="com.koxudaxi.ruff.RuffPostFormatProcessor"/>
-        <localInspection language="Python" shortName="RuffInspection" suppressId="Ruff"
-                         displayName="Ruff inspection"
-                         enabledByDefault="true" level="WARNING"
-                         implementationClass="com.koxudaxi.ruff.RuffInspection"/>
+<!--        <localInspection language="Python" shortName="RuffInspection" suppressId="Ruff"-->
+<!--                         displayName="Ruff inspection"-->
+<!--                         enabledByDefault="true" level="WARNING"-->
+<!--                         implementationClass="com.koxudaxi.ruff.RuffInspection"/>-->
+        <externalAnnotator language="Python" implementationClass="com.koxudaxi.ruff.RuffExternalAnnotator"/>
     </extensions>
     <projectListeners>
         <listener class="com.koxudaxi.ruff.RuffFileDocumentManagerListener"

--- a/src/com/koxudaxi/ruff/RuffExternalAnnotator.kt
+++ b/src/com/koxudaxi/ruff/RuffExternalAnnotator.kt
@@ -1,36 +1,62 @@
 package com.koxudaxi.ruff
 
+import com.intellij.codeHighlighting.HighlightDisplayLevel
+import com.intellij.codeInsight.daemon.HighlightDisplayKey
 import com.intellij.codeInspection.InspectionManager
+import com.intellij.codeInspection.InspectionProfile
 import com.intellij.codeInspection.ProblemHighlightType
 import com.intellij.lang.annotation.AnnotationHolder
 import com.intellij.lang.annotation.ExternalAnnotator
 import com.intellij.lang.annotation.HighlightSeverity
 import com.intellij.openapi.editor.Document
+import com.intellij.profile.codeInspection.InspectionProjectProfileManager
 import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import com.intellij.psi.util.PsiTreeUtil
 import com.jetbrains.python.psi.PyFile
+import com.jetbrains.python.psi.impl.PyFileImpl
 
 
 class RuffExternalAnnotator :
     ExternalAnnotator<RuffExternalAnnotator.RuffExternalAnnotatorInfo, RuffExternalAnnotator.RuffExternalAnnotatorResult>() {
     private val argsBase =
         listOf("--exit-zero", "--no-cache", "--no-fix", "--format", "json")
+    private val highlightSeverityLevels = mapOf<HighlightDisplayLevel, HighlightSeverity>(
+        HighlightDisplayLevel.ERROR to HighlightSeverity.ERROR,
+        HighlightDisplayLevel.WARNING to HighlightSeverity.WARNING,
+        HighlightDisplayLevel.WEAK_WARNING to HighlightSeverity.WEAK_WARNING,
+    )
+    private val problemHighlightTypeLevels = mapOf<HighlightDisplayLevel, ProblemHighlightType>(
+        HighlightDisplayLevel.ERROR to ProblemHighlightType.ERROR,
+        HighlightDisplayLevel.WARNING to ProblemHighlightType.WARNING,
+        HighlightDisplayLevel.WEAK_WARNING to ProblemHighlightType.WEAK_WARNING,
+    )
+    override fun getPairedBatchInspectionShortName(): String? {
+        return RuffInspection.INSPECTION_SHORT_NAME
+    }
+
+
 
     override fun collectInformation(file: PsiFile): RuffExternalAnnotatorInfo? {
         if (file !is PyFile) return null
         if (!file.isApplicableTo) return null
+        val profile: InspectionProfile = InspectionProjectProfileManager.getInstance(file.getProject()).currentProfile
+        val key = HighlightDisplayKey.find(RuffInspection.INSPECTION_SHORT_NAME)
+        if (!profile.isToolEnabled(key, file)) return null
+        if (file is PyFileImpl && !file.isAcceptedFor(RuffInspection::class.java)) return null
+        val level = profile.getErrorLevel(key, file)
+        val highlightDisplayLevel = highlightSeverityLevels[level] ?: return null
+        val problemHighlightType = problemHighlightTypeLevels[level] ?: return null
         val showRuleCode = RuffConfigService.getInstance(file.project).showRuleCode
         val commandArgs =  generateCommandArgs(file, argsBase)
-        return RuffExternalAnnotatorInfo(showRuleCode, commandArgs)
+        return RuffExternalAnnotatorInfo(showRuleCode, highlightDisplayLevel, problemHighlightType, commandArgs)
     }
 
     override fun doAnnotate(info: RuffExternalAnnotatorInfo): RuffExternalAnnotatorResult? {
-        val showRuleCode = info.showRuleCode
         val response = runRuff(info.commandArgs) ?: return null
         val result = parseJsonResponse(response)
-        return RuffExternalAnnotatorResult(showRuleCode, result)
+        return RuffExternalAnnotatorResult(info.showRuleCode, info.highlightDisplayLevel, info.problemHighlightType, result)
     }
 
     override fun apply(file: PsiFile, annotationResult: RuffExternalAnnotatorResult?, holder: AnnotationHolder) {
@@ -40,18 +66,17 @@ class RuffExternalAnnotator :
         val result = annotationResult.result
         val trimOriginalLength = file.text.trimEnd().length
         val document = PsiDocumentManager.getInstance(project).getDocument(file) ?: return
-        val t = document.text
-        val tt = file.text
+
         result.forEach {
             val psiElement = getPyElement(it, file, document) ?: return@forEach
             val builder = holder.newAnnotation(
-                HighlightSeverity.WARNING,
+                annotationResult.highlightDisplayLevel,
                 if (showRuleCode) "${it.code} ${it.message}" else it.message
             )
             if (it.fix != null) {
                 RuffQuickFix.create(it.fix, document)?.let { quickFix ->
                     val problemDescriptor = InspectionManager.getInstance(file.project)
-                        .createProblemDescriptor(psiElement, it.message, quickFix, ProblemHighlightType.WARNING, true)
+                        .createProblemDescriptor(psiElement, it.message, quickFix, annotationResult.problemHighlightType, true)
                     builder.needsUpdateOnTyping().newLocalQuickFix(quickFix, problemDescriptor).registerFix() }
             }
             if (isForFile(document, it, trimOriginalLength)) {
@@ -86,13 +111,18 @@ class RuffExternalAnnotator :
         }
     }
 
+
     data class RuffExternalAnnotatorInfo(
         val showRuleCode: Boolean,
+        val highlightDisplayLevel: HighlightSeverity,
+        val problemHighlightType: ProblemHighlightType,
         val commandArgs: CommandArgs
     )
 
     data class RuffExternalAnnotatorResult(
         val showRuleCode: Boolean,
+        val highlightDisplayLevel: HighlightSeverity,
+        val problemHighlightType: ProblemHighlightType,
         val result: List<Result>
     )
 }

--- a/src/com/koxudaxi/ruff/RuffExternalAnnotator.kt
+++ b/src/com/koxudaxi/ruff/RuffExternalAnnotator.kt
@@ -1,0 +1,146 @@
+package com.koxudaxi.ruff
+
+import com.intellij.codeInsight.intention.IntentionAction
+import com.intellij.lang.annotation.AnnotationHolder
+import com.intellij.lang.annotation.ExternalAnnotator
+import com.intellij.lang.annotation.HighlightSeverity
+import com.intellij.openapi.editor.Document
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.PsiDocumentManager
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import com.intellij.psi.util.PsiTreeUtil
+import com.jetbrains.python.psi.PyFile
+import com.jetbrains.python.psi.PyUtil
+
+
+class RuffExternalAnnotator :
+    ExternalAnnotator<RuffExternalAnnotator.RuffExternalAnnotatorInfo, RuffExternalAnnotator.RuffExternalAnnotatorResult>() {
+    private val argsBase =
+        listOf("--exit-zero", "--no-cache", "--no-fix", "--format", "json")
+
+    override fun collectInformation(file: PsiFile): RuffExternalAnnotatorInfo? {
+        if (file !is PyFile) return null
+        if (!file.isApplicableTo) return null
+        val showRuleCode = RuffConfigService.getInstance(file.project).showRuleCode
+        return RuffExternalAnnotatorInfo(file, showRuleCode)
+    }
+
+    override fun doAnnotate(info: RuffExternalAnnotatorInfo): RuffExternalAnnotatorResult? {
+        val pyFile = info.pyFile
+        val showRuleCode = info.showRuleCode
+        val response = executeOnPooledThread(null) {
+            runRuff(pyFile, argsBase)
+        } ?: return null
+        return RuffExternalAnnotatorResult(pyFile, showRuleCode, parseJsonResponse(response))
+    }
+
+    override fun apply(file: PsiFile, annotationResult: RuffExternalAnnotatorResult?, holder: AnnotationHolder) {
+        if (annotationResult == null) return
+        val pyFile = annotationResult.pyFile
+        val project = pyFile.project
+        val showRuleCode = annotationResult.showRuleCode
+        val document = PsiDocumentManager.getInstance(project).getDocument(pyFile) ?: return
+
+        annotationResult.result.forEach {
+            val psiElement = getPyElement(it, pyFile, document) ?: return@forEach
+            val builder = holder.newAnnotation(
+                HighlightSeverity.WARNING,
+                if (showRuleCode) "${it.code} ${it.message}" else it.message
+            ).range(psiElement)
+            if (it.fix != null) {
+                RuffIntentionFix.create(it.fix, document)?.let { builder.withFix(it) }
+            }
+            builder.create()
+        }
+
+    }
+
+    class RuffIntentionFix(private val edits: List<Edit>, private val message: String?) : IntentionAction {
+        override fun startInWriteAction(): Boolean = true
+        override fun getText(): String =
+            when (message) {
+                is String -> message
+                else -> DEFAULT_FIX_MESSAGE
+            }
+
+        private val DEFAULT_FIX_MESSAGE = "Quick fix with ruff"
+        override fun getFamilyName(): String =
+            when (message) {
+                is String -> message
+                else -> DEFAULT_FIX_MESSAGE
+            }
+
+        override fun isAvailable(project: Project, editor: Editor?, file: PsiFile?): Boolean = true
+        override fun invoke(project: Project, editor: Editor?, file: PsiFile?) {
+            if (file == null) return
+            PyUtil.updateDocumentUnblockedAndCommitted(
+                file
+            ) { document: Document ->
+                edits.forEach { edit ->
+                    document.replaceString(
+                        edit.range.startOffset,
+                        edit.range.endOffset,
+                        edit.content
+                    )
+                }
+
+            }
+        }
+
+        data class Edit(
+            val content: String,
+            val range: TextRange,
+        )
+
+        companion object {
+            fun create(fix: Fix, document: Document): RuffIntentionFix? {
+                return when {
+                    fix.edits != null -> {
+                        var offset = 0
+                        fix.edits.map {
+                            val range = document.getStartEndRange(it.location, it.endLocation, offset)
+                            offset = offset - range.length + it.content.length
+                            Edit(it.content, range)
+                        }
+                    }
+
+                    fix.location != null && fix.endLocation != null && fix.content != null -> listOf(
+                        Edit(
+                            fix.content,
+                            document.getStartEndRange(fix.location, fix.endLocation, 0)
+                        )
+                    )
+
+                    else -> null
+                }?.let {
+                    RuffIntentionFix(it, fix.message)
+                }
+            }
+        }
+    }
+
+    private fun getPyElement(result: Result, pyFile: PyFile, document: Document): PsiElement? {
+        document.getStartEndRange(result.location, result.endLocation, -1).let {
+            return PsiTreeUtil.findElementOfClassAtRange(
+                pyFile,
+                it.startOffset,
+                it.endOffset,
+                PsiElement::class.java
+            )
+        }
+    }
+
+    data class RuffExternalAnnotatorInfo(
+        val pyFile: PyFile,
+        val showRuleCode: Boolean
+    )
+
+    data class RuffExternalAnnotatorResult(
+        val pyFile: PyFile,
+        val showRuleCode: Boolean,
+        val result: List<Result>
+    )
+}

--- a/src/com/koxudaxi/ruff/RuffExternalAnnotator.kt
+++ b/src/com/koxudaxi/ruff/RuffExternalAnnotator.kt
@@ -1,19 +1,16 @@
 package com.koxudaxi.ruff
 
-import com.intellij.codeInsight.intention.IntentionAction
+import com.intellij.codeInspection.InspectionManager
+import com.intellij.codeInspection.ProblemHighlightType
 import com.intellij.lang.annotation.AnnotationHolder
 import com.intellij.lang.annotation.ExternalAnnotator
 import com.intellij.lang.annotation.HighlightSeverity
 import com.intellij.openapi.editor.Document
-import com.intellij.openapi.editor.Editor
-import com.intellij.openapi.project.Project
-import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import com.intellij.psi.util.PsiTreeUtil
 import com.jetbrains.python.psi.PyFile
-import com.jetbrains.python.psi.PyUtil
 
 
 class RuffExternalAnnotator :
@@ -25,107 +22,63 @@ class RuffExternalAnnotator :
         if (file !is PyFile) return null
         if (!file.isApplicableTo) return null
         val showRuleCode = RuffConfigService.getInstance(file.project).showRuleCode
-        return RuffExternalAnnotatorInfo(file, showRuleCode)
+        val commandArgs =  generateCommandArgs(file, argsBase)
+        return RuffExternalAnnotatorInfo(showRuleCode, commandArgs)
     }
 
     override fun doAnnotate(info: RuffExternalAnnotatorInfo): RuffExternalAnnotatorResult? {
-        val pyFile = info.pyFile
         val showRuleCode = info.showRuleCode
-        val response = executeOnPooledThread(null) {
-            runRuff(pyFile, argsBase)
-        } ?: return null
-        return RuffExternalAnnotatorResult(pyFile, showRuleCode, parseJsonResponse(response))
+        val response = runRuff(info.commandArgs) ?: return null
+        val result = parseJsonResponse(response)
+        return RuffExternalAnnotatorResult(showRuleCode, result)
     }
 
     override fun apply(file: PsiFile, annotationResult: RuffExternalAnnotatorResult?, holder: AnnotationHolder) {
         if (annotationResult == null) return
-        val pyFile = annotationResult.pyFile
-        val project = pyFile.project
+        val project = file.project
         val showRuleCode = annotationResult.showRuleCode
-        val document = PsiDocumentManager.getInstance(project).getDocument(pyFile) ?: return
-
-        annotationResult.result.forEach {
-            val psiElement = getPyElement(it, pyFile, document) ?: return@forEach
+        val result = annotationResult.result
+        val trimOriginalLength = file.text.trimEnd().length
+        val document = PsiDocumentManager.getInstance(project).getDocument(file) ?: return
+        val t = document.text
+        val tt = file.text
+        result.forEach {
+            val psiElement = getPyElement(it, file, document) ?: return@forEach
             val builder = holder.newAnnotation(
                 HighlightSeverity.WARNING,
                 if (showRuleCode) "${it.code} ${it.message}" else it.message
-            ).range(psiElement)
+            )
             if (it.fix != null) {
-                RuffIntentionFix.create(it.fix, document)?.let { builder.withFix(it) }
+                RuffQuickFix.create(it.fix, document)?.let { quickFix ->
+                    val problemDescriptor = InspectionManager.getInstance(file.project)
+                        .createProblemDescriptor(psiElement, it.message, quickFix, ProblemHighlightType.WARNING, true)
+                    builder.needsUpdateOnTyping().newLocalQuickFix(quickFix, problemDescriptor).registerFix() }
+            }
+            if (isForFile(document, it, trimOriginalLength)) {
+                builder.fileLevel()
+            } else {
+                builder.range(psiElement)
             }
             builder.create()
         }
 
     }
 
-    class RuffIntentionFix(private val edits: List<Edit>, private val message: String?) : IntentionAction {
-        override fun startInWriteAction(): Boolean = true
-        override fun getText(): String =
-            when (message) {
-                is String -> message
-                else -> DEFAULT_FIX_MESSAGE
-            }
-
-        private val DEFAULT_FIX_MESSAGE = "Quick fix with ruff"
-        override fun getFamilyName(): String =
-            when (message) {
-                is String -> message
-                else -> DEFAULT_FIX_MESSAGE
-            }
-
-        override fun isAvailable(project: Project, editor: Editor?, file: PsiFile?): Boolean = true
-        override fun invoke(project: Project, editor: Editor?, file: PsiFile?) {
-            if (file == null) return
-            PyUtil.updateDocumentUnblockedAndCommitted(
-                file
-            ) { document: Document ->
-                edits.forEach { edit ->
-                    document.replaceString(
-                        edit.range.startOffset,
-                        edit.range.endOffset,
-                        edit.content
-                    )
-                }
-
+    private fun isForFile(document: Document, result: Result, trimOriginalLength: Int): Boolean {
+        if (result.location.row == 1 && result.location.column == 1) {
+            val range = document.getStartEndRange(result.location, result.endLocation, -   1)
+            val trimResultLength = range.substring(document.text).trimEnd().length
+            if (trimResultLength == trimOriginalLength) {
+                return true
             }
         }
-
-        data class Edit(
-            val content: String,
-            val range: TextRange,
-        )
-
-        companion object {
-            fun create(fix: Fix, document: Document): RuffIntentionFix? {
-                return when {
-                    fix.edits != null -> {
-                        var offset = 0
-                        fix.edits.map {
-                            val range = document.getStartEndRange(it.location, it.endLocation, offset)
-                            offset = offset - range.length + it.content.length
-                            Edit(it.content, range)
-                        }
-                    }
-
-                    fix.location != null && fix.endLocation != null && fix.content != null -> listOf(
-                        Edit(
-                            fix.content,
-                            document.getStartEndRange(fix.location, fix.endLocation, 0)
-                        )
-                    )
-
-                    else -> null
-                }?.let {
-                    RuffIntentionFix(it, fix.message)
-                }
-            }
-        }
+        return false
     }
 
-    private fun getPyElement(result: Result, pyFile: PyFile, document: Document): PsiElement? {
+    private fun getPyElement(result: Result, psiFile: PsiFile, document: Document): PsiElement? {
         document.getStartEndRange(result.location, result.endLocation, -1).let {
             return PsiTreeUtil.findElementOfClassAtRange(
-                pyFile,
+                psiFile,
                 it.startOffset,
                 it.endOffset,
                 PsiElement::class.java
@@ -134,12 +87,11 @@ class RuffExternalAnnotator :
     }
 
     data class RuffExternalAnnotatorInfo(
-        val pyFile: PyFile,
-        val showRuleCode: Boolean
+        val showRuleCode: Boolean,
+        val commandArgs: CommandArgs
     )
 
     data class RuffExternalAnnotatorResult(
-        val pyFile: PyFile,
         val showRuleCode: Boolean,
         val result: List<Result>
     )

--- a/src/com/koxudaxi/ruff/RuffInspection.kt
+++ b/src/com/koxudaxi/ruff/RuffInspection.kt
@@ -1,66 +1,22 @@
 package com.koxudaxi.ruff
 
-import com.intellij.codeInspection.LocalInspectionToolSession
-import com.intellij.codeInspection.ProblemsHolder
-import com.intellij.openapi.editor.Document
-import com.intellij.psi.PsiDocumentManager
-import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiElementVisitor
-import com.intellij.psi.util.PsiTreeUtil
+import com.intellij.codeInspection.ex.ExternalAnnotatorBatchInspection
+import com.intellij.codeInspection.options.OptPane
+import com.jetbrains.python.PyBundle
 import com.jetbrains.python.inspections.PyInspection
-import com.jetbrains.python.inspections.PyInspectionVisitor
-import com.jetbrains.python.psi.*
-import com.jetbrains.python.psi.types.TypeEvalContext
 
-class RuffInspection : PyInspection() {
-    override fun buildVisitor(
-        holder: ProblemsHolder,
-        isOnTheFly: Boolean,
-        session: LocalInspectionToolSession,
-    ): PsiElementVisitor = Visitor(holder, PyInspectionVisitor.getContext(session))
-
-    inner class Visitor(holder: ProblemsHolder, context: TypeEvalContext) :
-        PyInspectionVisitor(holder, context) {
-        private val argsBase =
-            listOf("--exit-zero", "--no-cache", "--no-fix", "--format", "json")
-
-        override fun visitPyFile(node: PyFile) {
-            super.visitPyFile(node)
-
-            inspectFile(node)
-        }
-
-        private fun inspectFile(pyFile: PyFile) {
-            if (!pyFile.isApplicableTo) return
-            val project = pyFile.project
-            val document = PsiDocumentManager.getInstance(project).getDocument(pyFile) ?: return
-            val response = executeOnPooledThread(null) {
-                runRuff(pyFile, argsBase)
-            } ?: return
-            val showRuleCode = RuffConfigService.getInstance(project).showRuleCode
-
-            parseJsonResponse(response).forEach {
-                val psiElement = getPyElement(it, pyFile, document) ?: return@forEach
-                registerProblem(
-                    psiElement,
-                    if (showRuleCode) "${it.code} ${it.message}" else it.message,
-                    it.fix?.let { fix ->
-                        RuffQuickFix.create(fix, document)
-                    })
-            }
-
-        }
-
-        private fun getPyElement(result: Result, pyFile: PyFile, document: Document): PsiElement? {
-            document.getStartEndRange(result.location, result.endLocation, -1).let {
-                return PsiTreeUtil.findElementOfClassAtRange(
-                    pyFile,
-                    it.startOffset,
-                    it.endOffset,
-                    PsiElement::class.java
-                )
-            }
-        }
+class RuffInspection : PyInspection(), ExternalAnnotatorBatchInspection {
+    var ignoredErrors: List<String> = ArrayList()
+    override fun getOptionsPane(): OptPane {
+        return OptPane.pane(
+        )
     }
 
+    override fun getShortName(): String {
+        return INSPECTION_SHORT_NAME
+    }
+
+    companion object {
+        const val INSPECTION_SHORT_NAME = "RuffInspection"
+    }
 }

--- a/src/com/koxudaxi/ruff/RuffInspection.kt
+++ b/src/com/koxudaxi/ruff/RuffInspection.kt
@@ -1,20 +1,10 @@
 package com.koxudaxi.ruff
 
 import com.intellij.codeInspection.ex.ExternalAnnotatorBatchInspection
-import com.intellij.codeInspection.options.OptPane
-import com.jetbrains.python.PyBundle
 import com.jetbrains.python.inspections.PyInspection
 
 class RuffInspection : PyInspection(), ExternalAnnotatorBatchInspection {
-    var ignoredErrors: List<String> = ArrayList()
-    override fun getOptionsPane(): OptPane {
-        return OptPane.pane(
-        )
-    }
-
-    override fun getShortName(): String {
-        return INSPECTION_SHORT_NAME
-    }
+    override fun getShortName(): String = INSPECTION_SHORT_NAME
 
     companion object {
         const val INSPECTION_SHORT_NAME = "RuffInspection"

--- a/src/com/koxudaxi/ruff/RuffQuickFix.kt
+++ b/src/com/koxudaxi/ruff/RuffQuickFix.kt
@@ -7,7 +7,7 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.TextRange
 import com.jetbrains.python.psi.PyUtil
 
-class RuffQuickFix(private val edits: List<Edit>, private val message: String?) :
+class RuffQuickFix(private val edits: List<Edit>, val message: String?) :
     LocalQuickFix {
     data class Edit(
         val content: String,


### PR DESCRIPTION
Related issue: 
https://github.com/koxudaxi/ruff-pycharm-plugin/issues/148

@KotlinIsland 
I apply the suggestion to the PR as test.
Could you please test the PR on your machine?
https://intellij-support.jetbrains.com/hc/en-us/community/posts/11275128092690-What-is-the-suggested-pattern-for-implementing-a-plugin-that-runs-an-external-command-that-generates-inspections-


