### PR TITLE
Support format

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -12,8 +12,8 @@
                 serviceImplementation="com.koxudaxi.ruff.RuffConfigService"/>
         <projectService serviceImplementation="com.koxudaxi.ruff.RuffFixService"/>
         <projectConfigurable groupId="tools" instance="com.koxudaxi.ruff.RuffConfigurable"/>
-        <postFormatProcessor
-                implementation="com.koxudaxi.ruff.RuffPostFormatProcessor"/>
+        <postFormatProcessor implementation="com.koxudaxi.ruff.RuffFixProcessor"/>
+        <postFormatProcessor implementation="com.koxudaxi.ruff.RuffFormatProcessor"/>
         <localInspection language="Python" shortName="RuffInspection" suppressId="Ruff"
                          displayName="Ruff inspection"
                          enabledByDefault="true" level="WARNING"

--- a/src/com/koxudaxi/ruff/Ruff.kt
+++ b/src/com/koxudaxi/ruff/Ruff.kt
@@ -58,6 +58,8 @@ val RUFF_LSP_COMMAND = when {
 }
 const val WSL_RUFF_LSP_COMMAND = "ruff-lsp"
 
+val ruffVersionCache: HashMap<String, RuffVersion> = hashMapOf()
+
 fun getRuffCommand(lsp: Boolean) = if (lsp) RUFF_LSP_COMMAND else RUFF_COMMAND
 
 fun getRuffWlsCommand(lsp: Boolean) = if (lsp) WSL_RUFF_LSP_COMMAND else WSL_RUFF_COMMAND
@@ -267,11 +269,16 @@ fun generateCommandArgs(
     val executable =
         ruffConfigService.ruffExecutablePath?.let { File(it) }?.takeIf { it.exists() } ?: detectRuffExecutable(
             project, ruffConfigService, false
-        ) ?: return null
+        ).apply { RuffCacheService.setVersion(project) } ?: return null
     val customConfigArgs = if (withoutConfig) null else ruffConfigService.ruffConfigPath?.let {
         args + listOf("--config", it)
     }
-    return CommandArgs(executable, project.basePath, stdin, (customConfigArgs ?: args) + if (stdin == null) listOf() else listOf("-"))
+    return CommandArgs(
+        executable,
+        project.basePath,
+        stdin,
+        (customConfigArgs ?: args) + if (stdin == null) listOf() else listOf("-")
+    )
 }
 
 

--- a/src/com/koxudaxi/ruff/RuffCacheService.kt
+++ b/src/com/koxudaxi/ruff/RuffCacheService.kt
@@ -1,0 +1,76 @@
+package com.koxudaxi.ruff
+
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.project.Project
+
+@Service(Service.Level.PROJECT)
+class RuffCacheService(val project: Project) {
+    private var version: RuffVersion? = null
+    private var hasFormatter: Boolean? = null
+
+    private fun hasFormatter(version: RuffVersion?): Boolean = version?.let { it >= RuffVersion(0, 0, 289) } == true
+
+    fun getVersion(): RuffVersion? {
+        val v = executeOnPooledThread(null) {
+            runRuff(project, listOf("--version"), true)
+        }
+        return v?.let { getOrPutVersionFromVersionCache(it) }
+    }
+
+    private fun getOrPutVersionFromVersionCache(version: String): RuffVersion? {
+        return ruffVersionCache.getOrPut(version) {
+            val versionList = version.trimEnd().split(" ").lastOrNull()?.split(".")?.map { it.toIntOrNull() ?: 0 } ?: return null
+            val ruffVersion = when {
+                versionList.size == 1 -> RuffVersion(versionList[0])
+                versionList.size == 2 -> RuffVersion(versionList[0], versionList[1])
+                versionList.size >= 3 -> RuffVersion(versionList[0], versionList[1], versionList[2])
+                else -> null
+            } ?: return null
+            ruffVersionCache[version] = ruffVersion
+            ruffVersion
+        }
+    }
+
+    internal fun getOrPutVersion(): RuffVersion? {
+        if (version != null) return version
+        return getVersion().apply {
+            version = this
+            hasFormatter = hasFormatter(this)
+        }
+    }
+
+    internal fun setVersion(): RuffVersion? {
+        return getVersion().also {
+            this.version = it
+            hasFormatter = hasFormatter(it)
+        }
+    }
+
+    internal fun hasFormatter(): Boolean {
+        if (hasFormatter == null) {
+            setVersion()
+        }
+        return hasFormatter ?: false
+    }
+
+    internal
+    companion object {
+        fun hasFormatter(project: Project): Boolean = getInstance(project).hasFormatter()
+
+        fun getVersion(project: Project): RuffVersion? {
+            return getInstance(project).getOrPutVersion()
+        }
+
+        fun setVersion(project: Project): RuffVersion? {
+            return getInstance(project).setVersion()
+        }
+
+        fun getOrPutVersionFromVersionCache(project: Project, version: String): RuffVersion? {
+            return getInstance(project).getOrPutVersionFromVersionCache(version)
+        }
+
+        internal fun getInstance(project: Project): RuffCacheService {
+            return project.getService(RuffCacheService::class.java)
+        }
+    }
+}

--- a/src/com/koxudaxi/ruff/RuffConfigPanel.form
+++ b/src/com/koxudaxi/ruff/RuffConfigPanel.form
@@ -77,7 +77,7 @@
               <grid row="7" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
-              <text value="CheckBox"/>
+              <text value="Use ruff format (Experimental) for version 0.0.289 or later"/>
             </properties>
           </component>
         </children>

--- a/src/com/koxudaxi/ruff/RuffConfigPanel.form
+++ b/src/com/koxudaxi/ruff/RuffConfigPanel.form
@@ -10,7 +10,7 @@
     </properties>
     <border type="none"/>
     <children>
-      <grid id="da542" layout-manager="GridLayoutManager" row-count="7" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+      <grid id="da542" layout-manager="GridLayoutManager" row-count="8" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
           <grid row="0" column="0" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
@@ -70,6 +70,14 @@
             </constraints>
             <properties>
               <text value="Use ruff-lsp (Experimental) for PyCharm Pro/IDEA Ultimate"/>
+            </properties>
+          </component>
+          <component id="d521d" class="javax.swing.JCheckBox" binding="useRuffFormatCheckBox">
+            <constraints>
+              <grid row="7" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value="CheckBox"/>
             </properties>
           </component>
         </children>

--- a/src/com/koxudaxi/ruff/RuffConfigPanel.kt
+++ b/src/com/koxudaxi/ruff/RuffConfigPanel.kt
@@ -37,6 +37,7 @@ class RuffConfigPanel(project: Project) {
     private lateinit var clearRuffConfigPathButton: JButton
     private lateinit var disableOnSaveOutsideOfProjectCheckBox: JCheckBox
     private lateinit var useRuffLspCheckBox: JCheckBox
+    private lateinit var useRuffFormatCheckBox: JCheckBox
     init {
         val ruffConfigService = getInstance(project)
         runRuffOnSaveCheckBox.isSelected = ruffConfigService.runRuffOnSave
@@ -50,6 +51,7 @@ class RuffConfigPanel(project: Project) {
         disableOnSaveOutsideOfProjectCheckBox.isEnabled = ruffConfigService.runRuffOnSave
         useRuffLspCheckBox.isEnabled = lspIsSupported
         useRuffLspCheckBox.isSelected = ruffConfigService.useRuffLsp
+        useRuffFormatCheckBox.isEnabled = lspIsSupported
         disableOnSaveOutsideOfProjectCheckBox.isSelected = ruffConfigService.disableOnSaveOutsideOfProject
         runRuffOnSaveCheckBox.addActionListener {
             disableOnSaveOutsideOfProjectCheckBox.isEnabled = runRuffOnSaveCheckBox.isSelected

--- a/src/com/koxudaxi/ruff/RuffConfigPanel.kt
+++ b/src/com/koxudaxi/ruff/RuffConfigPanel.kt
@@ -51,7 +51,8 @@ class RuffConfigPanel(project: Project) {
         disableOnSaveOutsideOfProjectCheckBox.isEnabled = ruffConfigService.runRuffOnSave
         useRuffLspCheckBox.isEnabled = lspIsSupported
         useRuffLspCheckBox.isSelected = ruffConfigService.useRuffLsp
-        useRuffFormatCheckBox.isEnabled = lspIsSupported
+        useRuffFormatCheckBox.isEnabled = true
+        useRuffFormatCheckBox.isSelected = ruffConfigService.useRuffFormat
         disableOnSaveOutsideOfProjectCheckBox.isSelected = ruffConfigService.disableOnSaveOutsideOfProject
         runRuffOnSaveCheckBox.addActionListener {
             disableOnSaveOutsideOfProjectCheckBox.isEnabled = runRuffOnSaveCheckBox.isSelected
@@ -177,6 +178,10 @@ class RuffConfigPanel(project: Project) {
         get() = disableOnSaveOutsideOfProjectCheckBox.isSelected
     val useRuffLsp: Boolean
         get() = useRuffLspCheckBox.isSelected
+
+    val useRuffFormat: Boolean
+        get() = useRuffFormatCheckBox.isSelected
+
     companion object {
         const val RUFF_EXECUTABLE_NOT_FOUND =  "Ruff executable not found"
         const val RUFF_LSP_EXECUTABLE_NOT_FOUND =  "Ruff-lsp executable not found"

--- a/src/com/koxudaxi/ruff/RuffConfigService.kt
+++ b/src/com/koxudaxi/ruff/RuffConfigService.kt
@@ -20,7 +20,7 @@ class RuffConfigService : PersistentStateComponent<RuffConfigService> {
     var ruffConfigPath: @SystemDependent String? = null
     var disableOnSaveOutsideOfProject: Boolean = true
     var useRuffLsp: Boolean = false
-    var useFormat: Boolean = false
+    var useRuffFormat: Boolean = false
 
     override fun getState(): RuffConfigService {
         return this

--- a/src/com/koxudaxi/ruff/RuffConfigService.kt
+++ b/src/com/koxudaxi/ruff/RuffConfigService.kt
@@ -20,6 +20,7 @@ class RuffConfigService : PersistentStateComponent<RuffConfigService> {
     var ruffConfigPath: @SystemDependent String? = null
     var disableOnSaveOutsideOfProject: Boolean = true
     var useRuffLsp: Boolean = false
+    var useFormat: Boolean = false
 
     override fun getState(): RuffConfigService {
         return this

--- a/src/com/koxudaxi/ruff/RuffConfigurable.kt
+++ b/src/com/koxudaxi/ruff/RuffConfigurable.kt
@@ -32,7 +32,8 @@ class RuffConfigurable internal constructor(project: Project) : Configurable {
                 ruffConfigService.globalRuffLspExecutablePath != configPanel.globalRuffLspExecutablePath ||
                 ruffConfigService.ruffConfigPath != configPanel.ruffConfigPath ||
                 ruffConfigService.disableOnSaveOutsideOfProject != configPanel.disableOnSaveOutsideOfProject ||
-                ruffConfigService.useRuffLsp != configPanel.useRuffLsp
+                ruffConfigService.useRuffLsp != configPanel.useRuffLsp ||
+                ruffConfigService.useRuffFormat != configPanel.useRuffFormat
 
     }
 
@@ -46,6 +47,7 @@ class RuffConfigurable internal constructor(project: Project) : Configurable {
         ruffConfigService.ruffConfigPath = configPanel.ruffConfigPath
         ruffConfigService.disableOnSaveOutsideOfProject = configPanel.disableOnSaveOutsideOfProject
         ruffConfigService.useRuffLsp = configPanel.useRuffLsp
+        ruffConfigService.useRuffFormat = configPanel.useRuffFormat
 
     }
 

--- a/src/com/koxudaxi/ruff/RuffFixProcessor.kt
+++ b/src/com/koxudaxi/ruff/RuffFixProcessor.kt
@@ -1,0 +1,11 @@
+package com.koxudaxi.ruff
+
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+
+
+class RuffFixProcessor : RuffPostFormatProcessor() {
+    override fun isEnabled(element: PsiElement): Boolean =
+        RuffConfigService.getInstance(element.project).runRuffOnReformatCode
+    override fun process(pyFile: PsiFile): String? = fix(pyFile)
+}

--- a/src/com/koxudaxi/ruff/RuffFormatProcessor.kt
+++ b/src/com/koxudaxi/ruff/RuffFormatProcessor.kt
@@ -7,7 +7,7 @@ import com.intellij.psi.PsiFile
 class RuffFormatProcessor : RuffPostFormatProcessor() {
     override fun isEnabled(element: PsiElement): Boolean {
         val ruffConfigService = RuffConfigService.getInstance(element.project)
-        return ruffConfigService.runRuffOnReformatCode && ruffConfigService.useFormat
+        return ruffConfigService.runRuffOnReformatCode && ruffConfigService.useRuffFormat
     }
     override fun process(pyFile: PsiFile): String? =  format(pyFile)
 }

--- a/src/com/koxudaxi/ruff/RuffFormatProcessor.kt
+++ b/src/com/koxudaxi/ruff/RuffFormatProcessor.kt
@@ -7,7 +7,7 @@ import com.intellij.psi.PsiFile
 class RuffFormatProcessor : RuffPostFormatProcessor() {
     override fun isEnabled(element: PsiElement): Boolean {
         val ruffConfigService = RuffConfigService.getInstance(element.project)
-        return ruffConfigService.runRuffOnReformatCode && ruffConfigService.useRuffFormat
+        return ruffConfigService.runRuffOnReformatCode && ruffConfigService.useRuffFormat && RuffCacheService.hasFormatter(element.project)
     }
     override fun process(pyFile: PsiFile): String? =  format(pyFile)
 }

--- a/src/com/koxudaxi/ruff/RuffFormatProcessor.kt
+++ b/src/com/koxudaxi/ruff/RuffFormatProcessor.kt
@@ -1,0 +1,13 @@
+package com.koxudaxi.ruff
+
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+
+
+class RuffFormatProcessor : RuffPostFormatProcessor() {
+    override fun isEnabled(element: PsiElement): Boolean {
+        val ruffConfigService = RuffConfigService.getInstance(element.project)
+        return ruffConfigService.runRuffOnReformatCode && ruffConfigService.useFormat
+    }
+    override fun process(pyFile: PsiFile): String? =  format(pyFile)
+}

--- a/src/com/koxudaxi/ruff/RuffLspServerSupportProvider.kt
+++ b/src/com/koxudaxi/ruff/RuffLspServerSupportProvider.kt
@@ -20,7 +20,7 @@ class RuffLspServerSupportProvider : LspServerSupportProvider {
         val executable =
             ruffConfigService.ruffLspExecutablePath?.let { File(it) }?.takeIf { it.exists() } ?: detectRuffExecutable(
                 project, ruffConfigService, true
-            ) ?: return
+            ).apply { RuffCacheService.setVersion(project) } ?: return
         val config = ruffConfigService.ruffConfigPath?.let { File(it) }?.takeIf { it.exists() }
         serverStarter.ensureServerStarted(RuffLspServerDescriptor(project, executable, config))
     }

--- a/src/com/koxudaxi/ruff/RuffLspServerSupportProvider.kt
+++ b/src/com/koxudaxi/ruff/RuffLspServerSupportProvider.kt
@@ -12,7 +12,11 @@ import java.io.File
 
 
 class RuffLspServerSupportProvider : LspServerSupportProvider {
-    override fun fileOpened(project: Project, file: VirtualFile, serverStarter: LspServerSupportProvider.LspServerStarter) {
+    override fun fileOpened(
+        project: Project,
+        file: VirtualFile,
+        serverStarter: LspServerSupportProvider.LspServerStarter
+    ) {
         val ruffConfigService = RuffConfigService.getInstance(project)
         if (!ruffConfigService.useRuffLsp) return
         if (!isInspectionEnabled(project)) return
@@ -20,9 +24,8 @@ class RuffLspServerSupportProvider : LspServerSupportProvider {
         val executable =
             ruffConfigService.ruffLspExecutablePath?.let { File(it) }?.takeIf { it.exists() } ?: detectRuffExecutable(
                 project, ruffConfigService, true
-            ).apply { RuffCacheService.setVersion(project) } ?: return
-        val config = ruffConfigService.ruffConfigPath?.let { File(it) }?.takeIf { it.exists() }
-        serverStarter.ensureServerStarted(RuffLspServerDescriptor(project, executable, config))
+            ) ?: return
+        serverStarter.ensureServerStarted(RuffLspServerDescriptor(project, executable, ruffConfigService))
     }
 
     fun isInspectionEnabled(project: Project): Boolean {
@@ -35,11 +38,23 @@ class RuffLspServerSupportProvider : LspServerSupportProvider {
 }
 
 
-private class RuffLspServerDescriptor(project: Project, val executable: File, val config: File?) : ProjectWideLspServerDescriptor(project, "Ruff") {
+private class RuffLspServerDescriptor(project: Project, val executable: File, val ruffConfig: RuffConfigService) :
+    ProjectWideLspServerDescriptor(project, "Ruff") {
+
     override fun isSupportedFile(file: VirtualFile) = file.extension == "py"
-    override fun createCommandLine(): GeneralCommandLine = GeneralCommandLine(executable.absolutePath)
+
+    private fun createBaseCommandLine(): GeneralCommandLine = GeneralCommandLine(executable.absolutePath)
+
+    override fun createCommandLine(): GeneralCommandLine {
+        val commandLine = createBaseCommandLine()
+        if (ruffConfig.useRuffFormat) {
+            return commandLine.withEnvironment("RUFF_EXPERIMENTAL_FORMATTER", "1")
+        }
+        return commandLine
+    }
+
     override fun createInitializationOptions(): Any? {
-        if (config == null) return null
+        val config = ruffConfig.ruffConfigPath?.let { File(it) }?.takeIf { it.exists() } ?: return null
         return InitOptions(Settings(listOf("--config", config.absolutePath)))
     }
 

--- a/src/com/koxudaxi/ruff/RuffPostFormatProcessor.kt
+++ b/src/com/koxudaxi/ruff/RuffPostFormatProcessor.kt
@@ -12,12 +12,12 @@ import com.jetbrains.python.psi.PyUtil
 abstract class RuffPostFormatProcessor : PostFormatProcessor {
     override fun processElement(source: PsiElement, settings: CodeStyleSettings): PsiElement = source
     override fun processText(source: PsiFile, rangeToReformat: TextRange, settings: CodeStyleSettings): TextRange {
-        if (!RuffConfigService.getInstance(source.project).runRuffOnReformatCode) return TextRange.EMPTY_RANGE
+        if (!isEnabled(source)) return TextRange.EMPTY_RANGE
         val pyFile = source.containingFile
         if (!pyFile.isApplicableTo) return TextRange.EMPTY_RANGE
 
         val formatted = executeOnPooledThread(null) {
-            fix(pyFile)
+            process(pyFile)
         } ?: return TextRange.EMPTY_RANGE
         val sourceDiffRange = diffRange(source.text, formatted) ?: return TextRange.EMPTY_RANGE
 

--- a/src/com/koxudaxi/ruff/RuffVersion.kt
+++ b/src/com/koxudaxi/ruff/RuffVersion.kt
@@ -1,0 +1,12 @@
+package com.koxudaxi.ruff
+
+class RuffVersion(private val major: Int, private val minor: Int = 0, private val patch: Int = 0) :
+    Comparable<RuffVersion> {
+    override fun compareTo(other: RuffVersion): Int =
+        when {
+            major != other.major -> major - other.major
+            minor != other.minor -> minor - other.minor
+            else -> patch - other.patch
+        }
+
+}


### PR DESCRIPTION
Ruff supports `format` subcommand as an experimental feature.
The PR should support the feature as optional. 
## Related Issues
https://github.com/koxudaxi/ruff-pycharm-plugin/issues/257
https://github.com/astral-sh/ruff/issues/7358