### PR TITLE
Fixed a bug that called ruff command infinitely

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased]
+- Fixed a bug that called ruff command infinitely [[#272](https://github.com/koxudaxi/ruff-pycharm-plugin/pull/272)]
 
 ## [0.0.21] - 2023-09-20
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,7 @@ pluginUntilBuild = 232.*
 
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
 platformType = PY
-platformVersion = 2023.2
+platformVersion = 2023.2.1
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ pluginGroup = com.koxudaxi.ruff
 pluginName = Ruff
 pluginRepositoryUrl = https://github.com/koxudaxi/ruff-pycharm-plugin
 # SemVer format -> https://semver.org
-pluginVersion = 0.0.21
+pluginVersion = 0.0.22
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 232

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -8,6 +8,7 @@
     <depends>com.intellij.modules.platform</depends>
     <depends optional="true" config-file="only-ultimate.xml">com.intellij.modules.ultimate</depends>
     <extensions defaultExtensionNs="com.intellij">
+        <postStartupActivity implementation="com.koxudaxi.ruff.RuffProjectInitializer"/>
         <projectService
                 serviceImplementation="com.koxudaxi.ruff.RuffConfigService"/>
         <projectService serviceImplementation="com.koxudaxi.ruff.RuffFixService"/>

--- a/src/com/koxudaxi/ruff/Ruff.kt
+++ b/src/com/koxudaxi/ruff/Ruff.kt
@@ -271,7 +271,7 @@ fun generateCommandArgs(
     val executable =
         ruffConfigService.ruffExecutablePath?.let { File(it) }?.takeIf { it.exists() } ?: detectRuffExecutable(
             project, ruffConfigService, false
-        ).apply { RuffCacheService.setVersion(project) } ?: return null
+        ) ?: return null
     val customConfigArgs = if (withoutConfig) null else ruffConfigService.ruffConfigPath?.let {
         args + listOf("--config", it)
     }

--- a/src/com/koxudaxi/ruff/Ruff.kt
+++ b/src/com/koxudaxi/ruff/Ruff.kt
@@ -178,7 +178,7 @@ val PsiFile.isApplicableTo: Boolean
 fun runCommand(
     commandArgs: CommandArgs
 ): String? = runCommand(
-    commandArgs.executable, commandArgs.projectPath, commandArgs.stdin, *commandArgs.args.toTypedArray()
+    commandArgs.executable, commandArgs.project.basePath, commandArgs.stdin, *commandArgs.args.toTypedArray()
 )
 
 
@@ -228,12 +228,20 @@ fun runCommand(
             isCancelled -> throw RunCanceledByUserException()
 
             exitCode != 0 -> {
-                if (stderr.startsWith("error: TOML parse error at line ", ignoreCase = false)) {
-                    throw TOMLParseException()
+                when {
+                    stderr.startsWith("error: TOML parse error at line ", ignoreCase = false) -> {
+                        throw TOMLParseException()
+                    }
+                    stderr.startsWith("error: unexpected argument '--output-format' found", ignoreCase = false) -> {
+                        throw UnexpectedNewArgumentException(NewArgument.OUTPUT_FORMAT)
+                    }
+                    Regex("(-|format):\\d+:\\d+: E902 No such file or directory \\(os error 2\\)\n").findAll(stdout).count() == 2-> {
+                        throw UnexpectedNewArgumentException(NewArgument.FORMAT)
+                    }
+                    else -> throw PyExecutionException(
+                        "Error Running Ruff", executable.path, args.asList(), stdout, stderr, exitCode, emptyList()
+                    )
                 }
-                throw PyExecutionException(
-                    "Error Running Ruff", executable.path, args.asList(), stdout, stderr, exitCode, emptyList()
-                )
             }
 
             else -> stdout
@@ -250,7 +258,7 @@ fun runRuff(project: Project, args: List<String>, withoutConfig: Boolean = false
 
 
 data class CommandArgs(
-    val executable: File, val projectPath: @SystemDependent String?,
+    val executable: File, val project: Project,
     val stdin: ByteArray?, val args: List<String>,
 )
 
@@ -277,7 +285,7 @@ fun generateCommandArgs(
     }
     return CommandArgs(
         executable,
-        project.basePath,
+        project,
         stdin,
         (customConfigArgs ?: args) + if (stdin == null) listOf() else listOf("-")
     )
@@ -286,12 +294,22 @@ fun generateCommandArgs(
 
 class TOMLParseException : ExecutionException("TOML parse error")
 
+enum class NewArgument(val argument: String) {
+    OUTPUT_FORMAT("--output-format"),
+    FORMAT("--format")
+}
+open class UnexpectedArgumentException(argument: String) : ExecutionException("Unexpected argument: $argument")
+class UnexpectedNewArgumentException(newArgument: NewArgument) : UnexpectedArgumentException(newArgument.argument)
+
 fun runRuff(commandArgs: CommandArgs): String? {
     return try {
         runCommand(commandArgs)
     } catch (_: RunCanceledByUserException) {
         null
     } catch (_: TOMLParseException) {
+        null
+    } catch (e: UnexpectedNewArgumentException) {
+        RuffCacheService.getInstance(commandArgs.project).clearVersion()
         null
     }
 }

--- a/src/com/koxudaxi/ruff/Ruff.kt
+++ b/src/com/koxudaxi/ruff/Ruff.kt
@@ -349,6 +349,16 @@ inline fun <reified T> executeOnPooledThread(
     }
 }
 
+inline fun executeOnPooledThread(crossinline action: () -> Unit) {
+    ApplicationManager.getApplication().executeOnPooledThread {
+        try {
+            action.invoke()
+        } catch (_: PyExecutionException) {
+        } catch (_: ProcessNotCreatedException) {
+        }
+    }
+}
+
 fun parseJsonResponse(response: String): List<Result> = try {
     json.decodeFromString(response)
 } catch (_: SerializationException) {

--- a/src/com/koxudaxi/ruff/RuffCacheService.kt
+++ b/src/com/koxudaxi/ruff/RuffCacheService.kt
@@ -41,6 +41,10 @@ class RuffCacheService(val project: Project) {
         hasOutputFormat = version?.hasOutputFormat
     }
 
+    internal fun clearVersion() {
+        setVersion(null)
+    }
+
     internal fun setVersion() {
         return setVersionFromCommand()
     }

--- a/src/com/koxudaxi/ruff/RuffCacheService.kt
+++ b/src/com/koxudaxi/ruff/RuffCacheService.kt
@@ -9,8 +9,10 @@ class RuffCacheService(val project: Project) {
     private var hasFormatter: Boolean? = null
     private var hasOutputFormat: Boolean? = null
 
-
-    private fun getVersion(): RuffVersion? =
+    fun getVersion(): RuffVersion? {
+        return version
+    }
+    private fun getVersionFromCommand(): RuffVersion? =
         // TODO: Move to background task to avoid blocking UI thread
         executeOnPooledThread(null) {
             runRuff(project, listOf("--version"), true)
@@ -39,7 +41,7 @@ class RuffCacheService(val project: Project) {
     }
 
     internal fun setVersion(): RuffVersion? {
-        return getVersion().apply { setVersion(this) }
+        return getVersionFromCommand().apply { setVersion(this) }
     }
 
     internal fun hasFormatter(): Boolean {

--- a/src/com/koxudaxi/ruff/RuffCacheService.kt
+++ b/src/com/koxudaxi/ruff/RuffCacheService.kt
@@ -35,6 +35,7 @@ class RuffCacheService(val project: Project) {
         }
     }
 
+    @Synchronized
     private fun setVersion(version: RuffVersion?) {
         this.version = version
         hasFormatter = version?.hasFormatter

--- a/src/com/koxudaxi/ruff/RuffConfigurable.kt
+++ b/src/com/koxudaxi/ruff/RuffConfigurable.kt
@@ -52,12 +52,6 @@ class RuffConfigurable internal constructor(project: Project) : Configurable {
         ruffCacheService.setVersion()
     }
 
-    private val useGlobalRuff: Boolean get() {
-        if (ruffConfigService.alwaysUseGlobalRuff) return true
-        if (ruffConfigService.projectRuffExecutablePath is String) return false
-        return ruffConfigService.globalRuffExecutablePath is String
-    }
-
     override fun disposeUIResources() {
     }
 }

--- a/src/com/koxudaxi/ruff/RuffConfigurable.kt
+++ b/src/com/koxudaxi/ruff/RuffConfigurable.kt
@@ -8,6 +8,7 @@ import javax.swing.JComponent
 class RuffConfigurable internal constructor(project: Project) : Configurable {
     private val ruffConfigService: RuffConfigService = RuffConfigService.getInstance(project)
     private val configPanel: RuffConfigPanel = RuffConfigPanel(project)
+    private val ruffCacheService: RuffCacheService = RuffCacheService.getInstance(project)
     override fun getDisplayName(): String {
         return "Ruff"
     }
@@ -48,7 +49,13 @@ class RuffConfigurable internal constructor(project: Project) : Configurable {
         ruffConfigService.disableOnSaveOutsideOfProject = configPanel.disableOnSaveOutsideOfProject
         ruffConfigService.useRuffLsp = configPanel.useRuffLsp
         ruffConfigService.useRuffFormat = configPanel.useRuffFormat
+        ruffCacheService.setVersion()
+    }
 
+    private val useGlobalRuff: Boolean get() {
+        if (ruffConfigService.alwaysUseGlobalRuff) return true
+        if (ruffConfigService.projectRuffExecutablePath is String) return false
+        return ruffConfigService.globalRuffExecutablePath is String
     }
 
     override fun disposeUIResources() {

--- a/src/com/koxudaxi/ruff/RuffPackageManagerListener.kt
+++ b/src/com/koxudaxi/ruff/RuffPackageManagerListener.kt
@@ -6,8 +6,10 @@ import com.jetbrains.python.packaging.PyPackageManager
 
 class RuffPackageManagerListener(project: Project) : PyPackageManager.Listener {
     private val ruffConfigService = RuffConfigService.getInstance(project)
+    private val ruffCacheService = RuffCacheService.getInstance(project)
     override fun packagesRefreshed(sdk: Sdk) {
         ruffConfigService.projectRuffExecutablePath = findRuffExecutableInSDK(sdk, false)?.absolutePath
         ruffConfigService.projectRuffLspExecutablePath = findRuffExecutableInSDK(sdk, true)?.absolutePath
+        ruffCacheService.setVersion()
     }
 }

--- a/src/com/koxudaxi/ruff/RuffProjectInitializer.kt
+++ b/src/com/koxudaxi/ruff/RuffProjectInitializer.kt
@@ -1,0 +1,23 @@
+package com.koxudaxi.ruff
+
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.project.DumbService
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.startup.ProjectActivity
+import com.intellij.serviceContainer.AlreadyDisposedException
+
+class RuffProjectInitializer : ProjectActivity {
+    override suspend fun execute(project: Project) {
+        if (ApplicationManager.getApplication().isUnitTestMode) return
+        if (project.isDisposed) return
+        DumbService.getInstance(project).smartInvokeLater {
+            try {
+                val ruffCacheService = RuffCacheService.getInstance(project)
+                if (ruffCacheService.getVersion() == null) {
+                    ruffCacheService.setVersion()
+                }
+            } catch (_: AlreadyDisposedException) {
+            }
+        }
+    }
+}


### PR DESCRIPTION
Related Issues: https://github.com/koxudaxi/ruff-pycharm-plugin/issues/270

Fixes due to this PR
- Run ruff --version asynchronously
- Run ruff --version only in the following three patterns
  - When the package list is updated  
  - When you save changes in the configuration screen
  - At project initialization (if version is undetected)