### PR TITLE
Fixed to correctly recognize empty list strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased]
+- Fixed to correctly recognize empty list strings [[#289](https://github.com/koxudaxi/ruff-pycharm-plugin/pull/289)]
 - Support 2023.3 EAP [[#284](https://github.com/koxudaxi/ruff-pycharm-plugin/pull/284)]
 
 ## [0.0.23] - 2023-10-03

--- a/src/com/koxudaxi/ruff/Ruff.kt
+++ b/src/com/koxudaxi/ruff/Ruff.kt
@@ -432,7 +432,7 @@ fun checkFixResult(sourceFile: SourceFile, fixResult: String?): String? {
     val noFixResult = runRuff(sourceFile, sourceFile.project.NO_FIX_ARGS) ?: return null
 
     // check the file is excluded
-    if (noFixResult == "[]\n") return null
+    if (noFixResult.trim() == "[]") return null
     return fixResult
 }
 


### PR DESCRIPTION
Closes: https://github.com/koxudaxi/ruff-pycharm-plugin/issues/161