### PR TITLE
Use preview only for non-stable server versions (<0.5.3)

### DIFF
--- a/src/com/koxudaxi/ruff/Ruff.kt
+++ b/src/com/koxudaxi/ruff/Ruff.kt
@@ -86,7 +86,13 @@ val NO_FIX_FORMAT_ARGS = ARGS_BASE + listOf("--no-fix", "--format", "json")
 val NO_FIX_OUTPUT_FORMAT_ARGS = ARGS_BASE + listOf("--no-fix", "--output-format", "json")
 val FORMAT_ARGS = listOf("format", "--force-exclude", "--quiet")
 val FORMAT_CHECK_ARGS = FORMAT_ARGS + listOf("--check")
-val LSP_PREVIEW_ARGS = listOf("server", "--preview")
+val LSP_ARGS_BASE = listOf("server")
+val PREVIEW_ARGS = listOf("--preview")
+val Project.LSP_ARGS: List<String>
+    get() = when {
+        RuffCacheService.hasStableServer(this) == true -> LSP_ARGS_BASE
+        else -> LSP_ARGS_BASE + PREVIEW_ARGS
+    }
 val Project.FIX_ARGS: List<String>
     get() = when {
         RuffCacheService.hasCheck(this) == true -> CHECK + FIX_ARGS_BASE

--- a/src/com/koxudaxi/ruff/RuffCacheService.kt
+++ b/src/com/koxudaxi/ruff/RuffCacheService.kt
@@ -10,6 +10,7 @@ class RuffCacheService(val project: Project) {
     private var hasOutputFormat: Boolean? = null
     private var hasCheck: Boolean? = null
     private var hasLsp: Boolean? = null
+    private var hasStableServer: Boolean? = null
 
     fun getVersion(): RuffVersion? {
         return version
@@ -45,6 +46,7 @@ class RuffCacheService(val project: Project) {
         hasOutputFormat = version?.hasOutputFormat
         hasCheck = version?.hasCheck
         hasLsp = version?.hasLsp
+        hasStableServer = version?.hasStableServer
     }
 
     internal fun clearVersion() {
@@ -70,6 +72,10 @@ class RuffCacheService(val project: Project) {
     internal fun hasLsp(): Boolean? {
         return hasLsp
     }
+
+    internal fun hasStableServer(): Boolean? {
+        return hasStableServer
+    }
     internal
     companion object {
         fun hasFormatter(project: Project): Boolean = getInstance(project).hasFormatter()
@@ -79,6 +85,8 @@ class RuffCacheService(val project: Project) {
         fun hasCheck(project: Project): Boolean? = getInstance(project).hasCheck()
 
         fun hasLsp(project: Project): Boolean? = getInstance(project).hasLsp()
+
+        fun hasStableServer(project: Project): Boolean? = getInstance(project).hasStableServer()
 
         internal fun getInstance(project: Project): RuffCacheService {
             return project.getService(RuffCacheService::class.java)

--- a/src/com/koxudaxi/ruff/RuffLspServerSupportProvider.kt
+++ b/src/com/koxudaxi/ruff/RuffLspServerSupportProvider.kt
@@ -86,7 +86,7 @@ abstract class RuffLspServerDescriptorBase(project: Project, val executable: Fil
 @Suppress("UnstableApiUsage")
 private class RuffServerServerDescriptor(project: Project, executable: File, ruffConfig: RuffConfigService) :
     RuffLspServerDescriptorBase(project, executable, ruffConfig) {
-    override fun createCommandLine(): GeneralCommandLine  = GeneralCommandLine(listOf(executable.absolutePath) + LSP_PREVIEW_ARGS)
+    override fun createCommandLine(): GeneralCommandLine  = GeneralCommandLine(listOf(executable.absolutePath) + project.LSP_ARGS)
 }
 @Serializable
 data class Settings(

--- a/src/com/koxudaxi/ruff/RuffVersion.kt
+++ b/src/com/koxudaxi/ruff/RuffVersion.kt
@@ -16,11 +16,13 @@ class RuffVersion(private val major: Int, private val minor: Int = 0, private va
     val hasCheck: Boolean get() = this >= SUPPORT_CHECK_VERSION
 
     val hasLsp: Boolean get() = this >= SUPPORT_LSP_VERSION
+
+    val hasStableServer: Boolean get() = this >= SUPPORT_STABLE_SERVER_VERSION
     companion object {
         val SUPPORT_FORMAT_VERSION = RuffVersion(0, 0, 289)
         val SUPPORT_OUTPUT_FORMAT_VERSION = RuffVersion(0, 0, 291)
         val SUPPORT_CHECK_VERSION = RuffVersion(0, 3, 0)
         val SUPPORT_LSP_VERSION = RuffVersion(0, 4, 5)
-
+        val SUPPORT_STABLE_SERVER_VERSION = RuffVersion(0, 5, 3)
     }
 }


### PR DESCRIPTION
Addresses issue #471 

Maybe a configuration to enable preview or specify additional command line arguments would be a good idea. 

This disables the preview for ruff versions >= 0.5.3 on server