### PR TITLE
fix: repo urls in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,14 @@
 
 ## [0.0.36] - 2024-09-03
 
-- Fix idea lsp server on wsl [[#486](https://github.com/koxudaxi/pydantic-pycharm-plugin/pull/#486)]
-- Support LSP4IJ, which is a third-party LSP server integration [[#437](https://github.com/koxudaxi/pydantic-pycharm-plugin/pull/#437)]
-- Use preview only for non-stable server versions (<0.5.3) [[#481](https://github.com/koxudaxi/pydantic-pycharm-plugin/pull/#481)]
-- Use rule or --explain dependent on version. [[#479](https://github.com/koxudaxi/pydantic-pycharm-plugin/pull/#479)]
+- Fix idea lsp server on wsl [[#486](https://github.com/koxudaxi/ruff-pycharm-plugin/pull/486)]
+- Support LSP4IJ, which is a third-party LSP server integration [[#437](https://github.com/koxudaxi/ruff-pycharm-plugin/pull/437)]
+- Use preview only for non-stable server versions (<0.5.3) [[#481](https://github.com/koxudaxi/ruff-pycharm-plugin/pull/481)]
+- Use rule or --explain dependent on version. [[#479](https://github.com/koxudaxi/ruff-pycharm-plugin/pull/479)]
 
 ## [0.0.35] - 2024-07-24
 
-- Support 242 EAP[[#461](https://github.com/koxudaxi/pydantic-pycharm-plugin/pull/#461)]
+- Support 242 EAP[[#461](https://github.com/koxudaxi/ruff-pycharm-plugin/pull/461)]
 
 ## [0.0.34] - 2024-06-28
 


### PR DESCRIPTION
Not exactly a big issue but I noticed the URLs in the changelog pointing to the pydantic plugin while updating plugins in PyCharm.

Cheers :)