### PR TITLE
Update LSP client change logic in RuffConfigurable.kt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased]
+- Update LSP client change logic in RuffConfigurable.kt [[#497](https://github.com/koxudaxi/ruff-pycharm-plugin/pull/497)]
 - Update LSP4IJ references and version [[#496](https://github.com/koxudaxi/ruff-pycharm-plugin/pull/496)]
 - LSP4IJ should be optional [[#494](https://github.com/koxudaxi/ruff-pycharm-plugin/pull/494)]
 


### PR DESCRIPTION
Refactor conditions to restart, start, or stop the LSP client based on changes in LSP client settings and enabling status. This ensures that LSP actions are more granular and specific to the conditions modified.