### PR TITLE
Remove projectRuffExecutablePath in config file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased]
+- Remove projectRuffExecutablePath in config file [[#505](https://github.com/koxudaxi/ruff-pycharm-plugin/pull/505)]
 
 ## [0.0.39] - 2024-09-12
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ pluginGroup = com.koxudaxi.ruff
 pluginName = Ruff
 pluginRepositoryUrl = https://github.com/koxudaxi/ruff-pycharm-plugin
 # SemVer format -> https://semver.org
-pluginVersion = 0.0.39
+pluginVersion = 0.0.40
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 242.20224.89

--- a/src/com/koxudaxi/ruff/RuffCacheService.kt
+++ b/src/com/koxudaxi/ruff/RuffCacheService.kt
@@ -11,6 +11,8 @@ class RuffCacheService(val project: Project) {
     private var hasCheck: Boolean? = null
     private var hasLsp: Boolean? = null
     private var hasStableServer: Boolean? = null
+    private var projectRuffExecutablePath: String? = null
+    private var projectRuffLspExecutablePath: String? = null
 
     fun getVersion(): RuffVersion? {
         return version
@@ -76,6 +78,25 @@ class RuffCacheService(val project: Project) {
     internal fun hasStableServer(): Boolean? {
         return hasStableServer
     }
+
+    internal fun getProjectRuffExecutablePath(): String? {
+        return projectRuffExecutablePath
+    }
+
+    @Synchronized
+    internal fun setProjectRuffExecutablePath(path: String?) {
+        projectRuffExecutablePath = path
+    }
+
+    internal fun getProjectRuffLspExecutablePath(): String? {
+        return projectRuffLspExecutablePath
+    }
+
+    @Synchronized
+    internal fun setProjectRuffLspExecutablePath(path: String?) {
+        projectRuffLspExecutablePath = path
+    }
+
     internal
     companion object {
         fun hasFormatter(project: Project): Boolean = getInstance(project).hasFormatter()

--- a/src/com/koxudaxi/ruff/RuffConfigPanel.kt
+++ b/src/com/koxudaxi/ruff/RuffConfigPanel.kt
@@ -46,6 +46,7 @@ class RuffConfigPanel(project: Project) {
 
     init {
         val ruffConfigService = getInstance(project)
+        val ruffCacheService = RuffCacheService.getInstance(project)
         runRuffOnSaveCheckBox.isSelected = ruffConfigService.runRuffOnSave
         runRuffOnSaveCheckBox.isEnabled = true
         runRuffOnReformatCodeCheckBox.isSelected = ruffConfigService.runRuffOnReformatCode
@@ -123,7 +124,7 @@ class RuffConfigPanel(project: Project) {
         }
         updateLspFields()
         alwaysUseGlobalRuffCheckBox.addActionListener { updateProjectExecutableFields() }
-        when (val projectRuffExecutablePath = ruffConfigService.projectRuffExecutablePath?.takeIf { File(it).exists() } ?: getProjectRuffExecutablePath(project, false)) {
+        when (val projectRuffExecutablePath = ruffCacheService.getProjectRuffExecutablePath()?.takeIf { File(it).exists() } ?: getProjectRuffExecutablePath(project, false)) {
             is String -> projectRuffExecutablePathField.text = projectRuffExecutablePath
             else -> {
                 projectRuffExecutablePathField.text = ""
@@ -132,7 +133,7 @@ class RuffConfigPanel(project: Project) {
         }
 
 
-        when (val projectRuffLspExecutablePath = ruffConfigService.projectRuffLspExecutablePath?.takeIf { File(it).exists() } ?: getProjectRuffExecutablePath(project, true)) {
+        when (val projectRuffLspExecutablePath = ruffCacheService.getProjectRuffLspExecutablePath()?.takeIf { File(it).exists() } ?: getProjectRuffExecutablePath(project, true)) {
             is String -> projectRuffLspExecutablePathField.text = projectRuffLspExecutablePath
             else -> {
                 projectRuffLspExecutablePathField.text = ""

--- a/src/com/koxudaxi/ruff/RuffConfigService.kt
+++ b/src/com/koxudaxi/ruff/RuffConfigService.kt
@@ -1,9 +1,6 @@
 package com.koxudaxi.ruff
 
-import com.intellij.openapi.components.PersistentStateComponent
-import com.intellij.openapi.components.Service
-import com.intellij.openapi.components.State
-import com.intellij.openapi.components.Storage
+import com.intellij.openapi.components.*
 import com.intellij.openapi.project.Project
 import com.intellij.util.xmlb.XmlSerializerUtil
 import org.jetbrains.annotations.SystemDependent
@@ -17,8 +14,6 @@ class RuffConfigService : PersistentStateComponent<RuffConfigService> {
     var globalRuffExecutablePath: @SystemDependent String? = null
     var globalRuffLspExecutablePath: @SystemDependent String? = null
     var alwaysUseGlobalRuff: Boolean = false
-    var projectRuffExecutablePath: @SystemDependent String? = null
-    var projectRuffLspExecutablePath: @SystemDependent String? = null
     var ruffConfigPath: @SystemDependent String? = null
     var disableOnSaveOutsideOfProject: Boolean = true
     var useRuffLsp: Boolean = false
@@ -35,20 +30,6 @@ class RuffConfigService : PersistentStateComponent<RuffConfigService> {
     override fun loadState(config: RuffConfigService) {
         XmlSerializerUtil.copyBean(config, this)
     }
-    val ruffExecutablePath: @SystemDependent String?
-        get() {
-        return when {
-            alwaysUseGlobalRuff -> globalRuffExecutablePath
-            else -> projectRuffExecutablePath ?: globalRuffExecutablePath
-        }
-    }
-    val ruffLspExecutablePath: @SystemDependent String?
-        get() {
-            return when {
-                alwaysUseGlobalRuff -> globalRuffLspExecutablePath
-                else -> projectRuffLspExecutablePath ?: globalRuffLspExecutablePath
-            }
-        }
     companion object {
         fun getInstance(project: Project): RuffConfigService {
             return project.getService(RuffConfigService::class.java)

--- a/src/com/koxudaxi/ruff/RuffPackageManagerListener.kt
+++ b/src/com/koxudaxi/ruff/RuffPackageManagerListener.kt
@@ -15,8 +15,8 @@ class RuffPackageManagerListener(private val project: Project) : PyPackageManage
         val ruffConfigService = RuffConfigService.getInstance(project)
         val ruffCacheService = RuffCacheService.getInstance(project)
         val ruffLspClientManager = RuffLspClientManager.getInstance(project)
-        ruffConfigService.projectRuffExecutablePath = findRuffExecutableInSDK(sdk, false)?.absolutePath
-        ruffConfigService.projectRuffLspExecutablePath = findRuffExecutableInSDK(sdk, true)?.absolutePath
+        ruffCacheService.setProjectRuffExecutablePath(findRuffExecutableInSDK(sdk, false)?.absolutePath)
+        ruffCacheService.setProjectRuffLspExecutablePath(findRuffExecutableInSDK(sdk, true)?.absolutePath)
         if (!lspSupported || !ruffConfigService.enableLsp) return
         ruffCacheService.setVersion {
             ApplicationManager.getApplication().invokeLater {

--- a/src/com/koxudaxi/ruff/lsp/intellij/RuffLspServerSupportProvider.kt
+++ b/src/com/koxudaxi/ruff/lsp/intellij/RuffLspServerSupportProvider.kt
@@ -27,7 +27,7 @@ class RuffLspServerSupportProvider : LspServerSupportProvider {
         if (ruffCacheService.getVersion() == null) return
         val descriptor = when {
             ruffConfigService.useRuffServer && ruffCacheService.hasLsp() == true -> {
-                getRuffExecutable(project, ruffConfigService, false)?.let {
+                getRuffExecutable(project, ruffConfigService, false, ruffCacheService)?.let {
                     RuffServerServerDescriptor(
                         project,
                         it,
@@ -36,7 +36,7 @@ class RuffLspServerSupportProvider : LspServerSupportProvider {
                 }
             }
 
-            else -> getRuffExecutable(project, ruffConfigService, true)?.let {
+            else -> getRuffExecutable(project, ruffConfigService, true, ruffCacheService)?.let {
                 RuffLspServerDescriptor(
                     project,
                     it,

--- a/src/com/koxudaxi/ruff/lsp/lsp4ij/RuffLanguageServer.kt
+++ b/src/com/koxudaxi/ruff/lsp/lsp4ij/RuffLanguageServer.kt
@@ -31,11 +31,11 @@ class RuffLanguageServer(project: Project) : ProcessStreamConnectionProvider() {
 
         val (ruffFile, args) = when {
                 ruffConfigService.useRuffServer && ruffCacheService.hasLsp() == true -> {
-                    val executable = getRuffExecutable(project, ruffConfigService, false) ?: return null
+                    val executable = getRuffExecutable(project, ruffConfigService, false, ruffCacheService) ?: return null
                     executable to project.LSP_ARGS + (getConfigArgs(ruffConfigService) ?: listOf())
                 }
                 else -> {
-                    val executable = getRuffExecutable(project, ruffConfigService, true) ?: return null
+                    val executable = getRuffExecutable(project, ruffConfigService, true, ruffCacheService) ?: return null
                     executable to listOf()
                 }
             }

--- a/src/com/koxudaxi/ruff/lsp/lsp4ij/RuffLanguageServerFactory.kt
+++ b/src/com/koxudaxi/ruff/lsp/lsp4ij/RuffLanguageServerFactory.kt
@@ -31,7 +31,7 @@ class RuffLanguageServerFactory : LanguageServerFactory, LanguageServerEnablemen
         val ruffCacheService = RuffCacheService.getInstance(project)
         if (ruffCacheService.getVersion() == null) return false
         if (ruffConfigService.useRuffServer && ruffCacheService.hasLsp() != true) return false
-        if (ruffConfigService.useRuffLsp && getRuffExecutable(project, ruffConfigService, true) == null ) return false
+        if (ruffConfigService.useRuffLsp && getRuffExecutable(project, ruffConfigService, true, ruffCacheService) == null ) return false
         return true
     }
 


### PR DESCRIPTION
Closes: https://github.com/koxudaxi/ruff-pycharm-plugin/issues/379
Moved project-level Ruff executable path management from RuffConfigService to RuffCacheService for better separation of concerns and improved code maintainability. Updated all relevant classes and functions to use the new methods in RuffCacheService for setting and retrieving these paths.