### PR TITLE
fix: enhance project-relative file path resolution in getProjectRelativeFilePath

### DIFF
--- a/src/com/koxudaxi/ruff/Ruff.kt
+++ b/src/com/koxudaxi/ruff/Ruff.kt
@@ -656,7 +656,10 @@ fun VirtualFile.isInProjectDir(project: Project): Boolean =
 fun getProjectRelativeFilePath(project: Project, virtualFile: VirtualFile): String? {
     val projectBasePath = project.basePath?.let { Paths.get(it) } ?: return null
     val filePath = virtualFile.canonicalPath?.let { Paths.get(it) } ?: return null
-    if (!project.modules.any { module -> module.basePath?.let { filePath.startsWith(it) } == true }) return null
+    if (!project.modules.any {
+        module -> module.basePath?.let { filePath.startsWith(it) } == true
+                || module.rootManager.contentRoots.any { contentRoot -> filePath.startsWith(contentRoot.path) }
+    }) return null
     return projectBasePath.relativize(filePath).pathString
 }
 


### PR DESCRIPTION
If there are several root directories in the project, they are not involved in defining the file as a file, which leads to incorrect definition of the ruff config.

Example of project structure: [project-some-roots.tar.gz](https://github.com/user-attachments/files/21567360/project-some-roots.tar.gz)
