### PR TITLE
Remove 'use configuration file closest to formatted file' and rely on ruffs own config file discovery

### DIFF
--- a/src/com/koxudaxi/ruff/RuffApplyService.kt
+++ b/src/com/koxudaxi/ruff/RuffApplyService.kt
@@ -58,10 +58,7 @@ class RuffApplyService(val project: Project) {
         try {
             val projectRef = project
 
-            val configPath = if (projectRef.configService.useClosestConfig)
-                findClosestRuffConfig(sourceFile)
-            else
-                null
+            val configPath = projectRef.configService.ruffConfigPath
 
             val fixArgs = if (configPath != null)
                 projectRef.FIX_ARGS + listOf("--config", configPath)
@@ -135,17 +132,4 @@ class RuffApplyService(val project: Project) {
             return project.getService(RuffApplyService::class.java)
         }
     }
-}
-
-fun findClosestRuffConfig(sourceFile: SourceFile): String? {
-    val virtualFile = sourceFile.virtualFile ?: return null
-    val configFiles = listOf("pyproject.toml", "ruff.toml")
-    
-    return generateSequence(Path(virtualFile.path)) { it.parent }
-        .firstNotNullOfOrNull { dir ->
-            configFiles
-                .map { dir.resolve(it) }
-                .firstOrNull { it.toFile().exists() }
-                ?.toString()
-        }
 }

--- a/src/com/koxudaxi/ruff/RuffApplyService.kt
+++ b/src/com/koxudaxi/ruff/RuffApplyService.kt
@@ -11,7 +11,6 @@ import com.intellij.openapi.editor.Document
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.PsiFile
-import kotlin.io.path.Path
 
 
 @Service(Service.Level.PROJECT)
@@ -60,10 +59,7 @@ class RuffApplyService(val project: Project) {
 
             val configPath = projectRef.configService.ruffConfigPath
 
-            val fixArgs = if (configPath != null)
-                projectRef.FIX_ARGS + listOf("--config", configPath)
-            else
-                projectRef.FIX_ARGS
+            val fixArgs = projectRef.FIX_ARGS
 
             val checkedFixed = runReadActionOnPooledThread(projectRef,null) {
                 if (projectRef.isDisposed) return@runReadActionOnPooledThread null

--- a/src/com/koxudaxi/ruff/RuffConfigPanel.form
+++ b/src/com/koxudaxi/ruff/RuffConfigPanel.form
@@ -391,14 +391,6 @@
           <grid row="5" column="0" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
       </hspacer>
-      <component id="9b2fc" class="javax.swing.JCheckBox" binding="useClosestConfigCheckbox">
-        <constraints>
-          <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-        </constraints>
-        <properties>
-          <text value="Use configuration file closest to formatted file"/>
-        </properties>
-      </component>
     </children>
   </grid>
   <buttonGroups>

--- a/src/com/koxudaxi/ruff/RuffConfigPanel.kt
+++ b/src/com/koxudaxi/ruff/RuffConfigPanel.kt
@@ -33,7 +33,6 @@ class RuffConfigPanel(project: Project) {
 
     private lateinit var projectRuffLspLabel: JLabel
     private lateinit var projectRuffLspExecutablePathField: JBTextField
-    private lateinit var useClosestConfigCheckbox: JCheckBox
     private lateinit var ruffConfigPathField: TextFieldWithBrowseButton
     private lateinit var clearRuffConfigPathButton: JButton
     private lateinit var disableOnSaveOutsideOfProjectCheckBox: JCheckBox
@@ -84,8 +83,7 @@ class RuffConfigPanel(project: Project) {
         hoverFeatureCheckBox.isSelected = ruffConfigService.hoverFeature
         useRuffImportOptimizerCheckBox.isSelected = ruffConfigService.useRuffImportOptimizer
         useRuffImportOptimizerCheckBox.isEnabled = true
-        ruffConfigPathField.textField.isEnabled = !ruffConfigService.useClosestConfig
-        useClosestConfigCheckbox.isSelected = ruffConfigService.useClosestConfig
+
 
         lsp4ijLinkLabel.addMouseListener(object : MouseAdapter() {
             override fun mouseClicked(e: MouseEvent?) {
@@ -167,15 +165,12 @@ class RuffConfigPanel(project: Project) {
             }
         }
 
-        useClosestConfigCheckbox.addActionListener {
-            val useClosest = useClosestConfigCheckbox.isSelected
-            ruffConfigPathField.isEnabled = !useClosest
-            ruffConfigPathField.textField.isEditable = !useClosest
-            clearRuffConfigPathButton.isEnabled = !useClosest
-        }
         ruffConfigPathField.apply {
             addBrowseFolderListener(null, FileChooserDescriptorFactory.createSingleFileDescriptor())
-            textField.isEditable = false
+            if (textField is JBTextField) {
+                (textField as JBTextField).emptyText.text = "Leave blank to auto-discover, or enter a path to override."
+            }
+            textField.isEditable = true
             textField.text = ruffConfigService.ruffConfigPath
         }
         clearRuffConfigPathButton.addActionListener {
@@ -298,8 +293,6 @@ class RuffConfigPanel(project: Project) {
         get() = hoverFeatureCheckBox.isSelected
     val useRuffImportOptimizer: Boolean
         get() = useRuffImportOptimizerCheckBox.isSelected
-    val useClosestConfig: Boolean
-        get() = useClosestConfigCheckbox.isSelected
     companion object {
         const val RUFF_EXECUTABLE_NOT_FOUND = "Ruff executable not found"
         const val RUFF_LSP_EXECUTABLE_NOT_FOUND = "Ruff-lsp executable not found"

--- a/src/com/koxudaxi/ruff/RuffConfigService.kt
+++ b/src/com/koxudaxi/ruff/RuffConfigService.kt
@@ -27,7 +27,6 @@ class RuffConfigService : PersistentStateComponent<RuffConfigService> {
     var diagnosticFeature: Boolean = true
     var formattingFeature: Boolean = true
     var useRuffImportOptimizer: Boolean = false
-    var useClosestConfig: Boolean = false
     var hoverFeature: Boolean = true
 
     override fun getState(): RuffConfigService {

--- a/src/com/koxudaxi/ruff/RuffConfigurable.kt
+++ b/src/com/koxudaxi/ruff/RuffConfigurable.kt
@@ -49,8 +49,7 @@ class RuffConfigurable internal constructor(val project: Project) : Configurable
                 ruffConfigService.diagnosticFeature != configPanel.diagnosticFeature ||
                 ruffConfigService.formattingFeature != configPanel.formattingFeature ||
                 ruffConfigService.hoverFeature != configPanel.hoverFeature ||
-                ruffConfigService.useRuffImportOptimizer != configPanel.useRuffImportOptimizer ||
-                ruffConfigService.useClosestConfig != configPanel.useClosestConfig
+                ruffConfigService.useRuffImportOptimizer != configPanel.useRuffImportOptimizer
 
 
     }
@@ -75,7 +74,6 @@ class RuffConfigurable internal constructor(val project: Project) : Configurable
         ruffConfigService.globalRuffLspExecutablePath = configPanel.globalRuffLspExecutablePath
         ruffConfigService.disableOnSaveOutsideOfProject = configPanel.disableOnSaveOutsideOfProject
         ruffConfigService.useRuffFormat = configPanel.useRuffFormat
-        ruffConfigService.useClosestConfig = configPanel.useClosestConfig
 
         if (ruffConfigService.enableRuffLogging != configPanel.enableRuffLogging) {
             if (configPanel.enableRuffLogging) {


### PR DESCRIPTION
Currently, the checkbox to 'use the closest configuration file' has unintuitive behaviour:

## Description of problem
If you press the checkbox, this plugin will use custom logic to find the closest configuration file. However, this logic does not match ruff's logic. 
- the plugin will not check whether the `pyproject.toml` file contains a `[tool.ruff]` section but instead use the first file that was found
    - the plugin will forcibly pass `--config <discovered_path>` to ruff, which in turn will disable ruff's internal autodiscovery
    - if a nested `pyproject.toml` has no `[tool.ruff]` section, ruff should go upwards to the parent directory. However, currently it does not do so and assumes the forcibly passed config is the correct one. This will in turn disable all settings from the parent config, as **ruff assumes we want to use the default configuration** (since no `[tool.ruff]` section was found). This is incorrect / unintuitive.

## Workaround for current behaviour
A workaround is to add
```
[tool.ruff]
extend = '../pyproject.toml'
```
to the nearest pyproject.toml.

OR

don't select the checkbox, don't pass a file -> this will enable ruffs autodiscovery. **This is very unintuitive**.

## The fix
This PR fixes the problem by removing the confusing checkbox. 
- Either you pass a custom config, which will be used
- Or you pass nothing and the normal autodiscovery inherent in ruff is used
