### PR TITLE
fix: add --stdin-filename to format command for config auto-discovery

### DIFF
--- a/src/com/koxudaxi/ruff/RuffApplyService.kt
+++ b/src/com/koxudaxi/ruff/RuffApplyService.kt
@@ -113,7 +113,7 @@ class RuffApplyService(val project: Project) {
             val formatCommandArgs = generateCommandArgs(
                 sourceFile.project,
                 sourceByte,
-                FORMAT_ARGS,
+                FORMAT_ARGS + getStdinFileNameArgs(sourceFile),
                 true,
                 configPath = configPath
             ) ?: return


### PR DESCRIPTION
## Summary
- Add `--stdin-filename` argument to the format command to enable ruff's config auto-discovery

Related PR #631