### PR TITLE
docs: clarify native Ruff guidance for PyCharm 2025.3+

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,14 @@
 
 A [`ruff`](https://github.com/charliermarsh/ruff) integration [plugin](https://plugins.jetbrains.com/plugin/20574-ruff) for [JetBrains PyCharm](https://www.jetbrains.com/pycharm/).
 
+## PyCharm 2025.3 and newer
+
+PyCharm 2025.3+ includes native Ruff support.
+If you are on PyCharm 2025.3 or newer, prefer the built-in Ruff integration:
+https://www.jetbrains.com/help/pycharm/lsp-tools.html
+
+This plugin is mainly useful for older PyCharm versions and JetBrains IDEs that do not include native Ruff support.
+
 See [documentation](https://koxudaxi.github.io/ruff-pycharm-plugin/) for more details.
 
 <!-- Plugin description -->
@@ -91,4 +99,3 @@ We are waiting for your contributions to `ruff-pycharm-plugin`!
   </td>
   </tr>
 </table>
-


### PR DESCRIPTION
## Summary
- add a clear note that PyCharm 2025.3+ has native Ruff support
- recommend built-in Ruff integration for 2025.3+ users
- clarify this plugin is mainly useful for older PyCharm versions and IDEs without native Ruff support

## Motivation
- follow-up for discussion in #656 and #643 to reduce user confusion

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added information about PyCharm 2025.3+ native Ruff support and plugin compatibility
  * Included guidance recommending the native integration for newer PyCharm versions while noting the plugin remains useful for older versions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->