### PR TITLE
Preserve Ruff format stdin args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-- Fix: centralize Ruff format arguments to preserve `--stdin-filename` handling
+- Fix: centralize Ruff format arguments to preserve `--stdin-filename` handling [[#668](https://github.com/koxudaxi/ruff-pycharm-plugin/pull/668)]
 
 ## [0.0.52] - 2025-12-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Fix: centralize Ruff format arguments to preserve `--stdin-filename` handling
+
 ## [0.0.52] - 2025-12-15
 
 - Fix: add --stdin-filename to format command for config auto-discovery [[#651](https://github.com/koxudaxi/ruff-pycharm-plugin/pull/651)]

--- a/src/com/koxudaxi/ruff/Ruff.kt
+++ b/src/com/koxudaxi/ruff/Ruff.kt
@@ -707,6 +707,9 @@ fun getStdinFileNameArgs(sourceFile: SourceFile): List<String> {
     } ?: emptyList()
 }
 
+fun buildFormatArgs(extraArgs: List<String> = emptyList(), stdinFileNameArgs: List<String> = emptyList()): List<String> =
+    FORMAT_ARGS + extraArgs + stdinFileNameArgs
+
 fun Document.getStartEndRange(startLocation: Location, endLocation: Location, offset: Int): TextRange {
     val start = getLineStartOffset(startLocation.row - 1) + startLocation.column + offset
     val lastLine = endLocation.row - 1

--- a/src/com/koxudaxi/ruff/Ruff.kt
+++ b/src/com/koxudaxi/ruff/Ruff.kt
@@ -184,6 +184,9 @@ val intellijLspClientSupported: Boolean
         } catch (e: NoClassDefFoundError) {
             intellijLspClientSupportedValue = false
             false
+        } catch (e: Exception) {
+            intellijLspClientSupportedValue = false
+            false
         }
     }
 

--- a/src/com/koxudaxi/ruff/RuffApplyService.kt
+++ b/src/com/koxudaxi/ruff/RuffApplyService.kt
@@ -113,7 +113,7 @@ class RuffApplyService(val project: Project) {
             val formatCommandArgs = generateCommandArgs(
                 sourceFile.project,
                 sourceByte,
-                FORMAT_ARGS + getStdinFileNameArgs(sourceFile),
+                buildFormatArgs(stdinFileNameArgs = getStdinFileNameArgs(sourceFile)),
                 true,
                 configPath = configPath
             ) ?: return

--- a/src/com/koxudaxi/ruff/RuffAsyncFormatter.kt
+++ b/src/com/koxudaxi/ruff/RuffAsyncFormatter.kt
@@ -58,7 +58,7 @@ class RuffAsyncFormatter : AsyncDocumentFormattingService() {
                         // When a range is specified, only run the format command.
                         val formatCommandArgs = generateCommandArgs(
                             sourceFile,
-                            FORMAT_ARGS + formatRange.formatRangeArgs(currentText),
+                            buildFormatArgs(formatRange.formatRangeArgs(currentText)),
                             false
                         )
                             ?: return@runCatching null
@@ -73,7 +73,7 @@ class RuffAsyncFormatter : AsyncDocumentFormattingService() {
                     if (!RuffConfigService.getInstance(formattingContext.project).useRuffFormat) {
                         return@runCatching assertResult(currentText, fixCommandStdout)
                     }
-                    val formatCommandArgs = generateCommandArgs(sourceFile, FORMAT_ARGS, false)
+                    val formatCommandArgs = generateCommandArgs(sourceFile, buildFormatArgs(), false)
                         ?: return@runCatching null
                     if (cancelled) {
                         return@runCatching null

--- a/testSrc/com/koxudaxi/ruff/RuffFormatArgsTest.kt
+++ b/testSrc/com/koxudaxi/ruff/RuffFormatArgsTest.kt
@@ -1,0 +1,22 @@
+package com.koxudaxi.ruff
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class RuffFormatArgsTest {
+    @Test
+    fun buildFormatArgsIncludesStdinFilename() {
+        assertEquals(
+            listOf("format", "--force-exclude", "--quiet", "--stdin-filename", "nested/example.py"),
+            buildFormatArgs(stdinFileNameArgs = listOf("--stdin-filename", "nested/example.py"))
+        )
+    }
+
+    @Test
+    fun buildFormatArgsPreservesExtraArgsBeforeStdinFilename() {
+        assertEquals(
+            listOf("format", "--force-exclude", "--quiet", "--range", "1:1-1:5", "--stdin-filename", "example.py"),
+            buildFormatArgs(listOf("--range", "1:1-1:5"), listOf("--stdin-filename", "example.py"))
+        )
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed handling of `--stdin-filename` argument in Ruff formatting commands to ensure proper preservation during argument construction.

* **Tests**
  * Added test coverage for format argument construction to verify correct argument ordering and composition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->