### PR TITLE
Fix WSL local project LSP URIs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -161,6 +161,37 @@ jobs:
       #   with:
       #     files: ${{ github.workspace }}/build/reports/kover/report.xml
 
+  testWindowsWslPaths:
+    name: Test WSL paths on Windows
+    needs: [ build ]
+    runs-on: windows-latest
+    steps:
+
+      - name: Fetch Sources
+        uses: actions/checkout@v5
+
+      - name: Setup Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 21
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-home-cache-cleanup: true
+
+      - name: Run WSL path tests
+        shell: cmd
+        run: gradlew.bat test --tests "*RuffStdinFilenameArgsTest" --tests "*RuffWslUriSupportTest" --tests "*RuffLspServerSupportProviderTest"
+
+      - name: Collect Tests Result
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: tests-result-windows-wsl-paths
+          path: ${{ github.workspace }}/build/reports/tests
+
   # Run Qodana inspections and provide report
   inspectCode:
     name: Inspect code
@@ -251,7 +282,7 @@ jobs:
   releaseDraft:
     name: Release draft
     if: github.event_name != 'pull_request'
-    needs: [ build, test, inspectCode, verify ]
+    needs: [ build, test, testWindowsWslPaths, inspectCode, verify ]
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-- Fix Ruff server startup for local WSL projects on Windows
+- Fix Ruff server startup for local WSL projects on Windows [[#669](https://github.com/koxudaxi/ruff-pycharm-plugin/pull/669)]
 
 ## [0.0.52] - 2025-12-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Fix Ruff server startup for local WSL projects on Windows
+
 ## [0.0.52] - 2025-12-15
 
 - Fix: add --stdin-filename to format command for config auto-discovery [[#651](https://github.com/koxudaxi/ruff-pycharm-plugin/pull/651)]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,7 +10,7 @@ changelog = "2.2.1"
 gradleIntelliJPlugin = "2.14.0"
 qodana = "2025.3.2"
 kover = "0.9.7"
-lsp4ij = "0.11.0"
+lsp4ij = "0.19.2"
 
 [libraries]
 tuweni = { group = "org.apache.tuweni", name = "tuweni-toml", version.ref = "tuweni" }

--- a/src/com/koxudaxi/ruff/Ruff.kt
+++ b/src/com/koxudaxi/ruff/Ruff.kt
@@ -726,7 +726,7 @@ internal fun resolveStdinFileName(
     wslPath: String?
 ): String? {
     if (executableRunsInWsl) {
-        return wslPath ?: filePath
+        return wslPath ?: projectRelativeFilePath ?: filePath
     }
     return toWindowsWslUncPath(filePath) ?: projectRelativeFilePath
 }

--- a/src/com/koxudaxi/ruff/Ruff.kt
+++ b/src/com/koxudaxi/ruff/Ruff.kt
@@ -527,15 +527,21 @@ data class CommandArgs(
     val stdin: ByteArray?, val args: List<String>,
 )
 
-fun generateCommandArgs(sourceFile: SourceFile, args: List<String>, setStdin: Boolean, configPath: String? = null): CommandArgs? =
-    generateCommandArgs(
-        sourceFile.project,
+fun generateCommandArgs(sourceFile: SourceFile, args: List<String>, setStdin: Boolean, configPath: String? = null): CommandArgs? {
+    val project = sourceFile.project
+    val ruffConfigService = project.configService
+    val ruffCacheService = RuffCacheService.getInstance(project)
+    val executable = getRuffExecutable(project, ruffConfigService, false, ruffCacheService) ?: return null
+    return generateCommandArgs(
+        project,
         if (setStdin) sourceFile.asStdin else null,
-        args + getStdinFileNameArgs(sourceFile),
+        args + getStdinFileNameArgs(sourceFile, executable),
         true,
         false,
-        configPath
+        configPath,
+        executable
     )
+}
 
 fun generateCommandArgs(
     project: Project,
@@ -543,17 +549,18 @@ fun generateCommandArgs(
     args: List<String>,
     addStdinOption: Boolean,
     withoutConfig: Boolean = false,
-    configPath: String? = null
+    configPath: String? = null,
+    executable: File? = null
 ): CommandArgs? {
     val ruffConfigService = project.configService
     val ruffCacheService = RuffCacheService.getInstance(project)
-    val executable =
-        getRuffExecutable(project, ruffConfigService, false, ruffCacheService) ?: return null
+    val resolvedExecutable =
+        executable ?: getRuffExecutable(project, ruffConfigService, false, ruffCacheService) ?: return null
     val customConfigArgs = if (withoutConfig) null else if(configPath != null) args + listOf(CONFIG_ARG, configPath) else ruffConfigService.ruffConfigPath?.let {
         args + listOf(CONFIG_ARG, it)
     }
     return CommandArgs(
-        executable,
+        resolvedExecutable,
         project,
         stdin,
         (customConfigArgs ?: args) + if (stdin == null && !addStdinOption) listOf() else listOf("-")
@@ -588,18 +595,29 @@ fun runRuff(commandArgs: CommandArgs, stdin: ByteArray? = null): String? {
 fun <T> runRuffInBackground(
     sourceFile: SourceFile, args: List<String>, callback: (String?) -> T
 ): ProgressIndicator? =
-    runRuffInBackground(
-        sourceFile.project,
-        sourceFile.asStdin,
-        args + getStdinFileNameArgs(sourceFile),
-        "running ruff ${sourceFile.name}",
-        callback
-    )
+    sourceFile.project.let { project ->
+        val ruffConfigService = project.configService
+        val ruffCacheService = RuffCacheService.getInstance(project)
+        val executable = getRuffExecutable(project, ruffConfigService, false, ruffCacheService) ?: return null
+        runRuffInBackground(
+            project,
+            sourceFile.asStdin,
+            args + getStdinFileNameArgs(sourceFile, executable),
+            "running ruff ${sourceFile.name}",
+            executable = executable,
+            callback = callback
+        )
+    }
 
 fun <T> runRuffInBackground(
-    project: Project, stdin: ByteArray?, args: List<String>, description: String, callback: (String?) -> T
+    project: Project,
+    stdin: ByteArray?,
+    args: List<String>,
+    description: String,
+    executable: File? = null,
+    callback: (String?) -> T
 ): ProgressIndicator? {
-    val commandArgs = generateCommandArgs(project, stdin, args, true) ?: return null
+    val commandArgs = generateCommandArgs(project, stdin, args, true, executable = executable) ?: return null
     val task = object : Task.Backgroundable(project, StringUtil.toTitleCase(description), true) {
         override fun run(indicator: ProgressIndicator) {
             indicator.text = "$description..."
@@ -701,25 +719,41 @@ fun getProjectRelativeFilePath(project: Project, virtualFile: VirtualFile): Stri
     return projectBasePath.relativize(filePath).pathString
 }
 
-fun getStdinFileNameArgs(sourceFile: SourceFile): List<String> {
+internal fun resolveStdinFileName(
+    filePath: String,
+    projectRelativeFilePath: String?,
+    executableRunsInWsl: Boolean,
+    wslPath: String?
+): String? {
+    if (executableRunsInWsl) {
+        return wslPath ?: filePath
+    }
+    return toWindowsWslUncPath(filePath) ?: projectRelativeFilePath
+}
+
+fun getStdinFileNameArgs(sourceFile: SourceFile, executable: File): List<String> {
     val virtualFile = sourceFile.virtualFile ?: return emptyList()
     val pythonSdk = sourceFile.project.preferredPythonSdk
+    val filePath = virtualFile.canonicalPath ?: virtualFile.path
+    val projectRelativeFilePath = getProjectRelativeFilePath(sourceFile.project, virtualFile)
+    val executableRunsInWsl = WslPath.isWslUncPath(executable.path)
 
-    if (pythonSdk?.isWsl == true) {
+    val wslPath = if (pythonSdk?.isWsl == true && executableRunsInWsl) {
         val wslTargetConfig =
             (pythonSdk.sdkAdditionalData as? PyTargetAwareAdditionalData)
                 ?.targetEnvironmentConfiguration as? WslTargetEnvironmentConfiguration
         val wslDistribution = wslTargetConfig?.distribution
-        val wslPath = try {
+        try {
             wslDistribution?.getWslPath(virtualFile.toNioPath())
         } catch (_: Exception) {
             null
-        } ?: virtualFile.canonicalPath ?: return emptyList()
-        return listOf("--stdin-filename", wslPath)
+        }
+    } else {
+        null
     }
 
-    return getProjectRelativeFilePath(sourceFile.project, virtualFile)?.let { projectRelativeFilePath ->
-        listOf("--stdin-filename", projectRelativeFilePath)
+    return resolveStdinFileName(filePath, projectRelativeFilePath, executableRunsInWsl, wslPath)?.let { stdinFileName ->
+        listOf("--stdin-filename", stdinFileName)
     } ?: emptyList()
 }
 

--- a/src/com/koxudaxi/ruff/RuffApplyService.kt
+++ b/src/com/koxudaxi/ruff/RuffApplyService.kt
@@ -109,13 +109,16 @@ class RuffApplyService(val project: Project) {
                 checkedFixed is String && checkedFixed.isNotEmpty() -> checkedFixed.toCharArray().toByteArrayAndClear()
                 else -> sourceFile.asStdin
             } ?: return
+            val ruffCacheService = RuffCacheService.getInstance(projectRef)
+            val executable = getRuffExecutable(projectRef, projectRef.configService, false, ruffCacheService) ?: return
 
             val formatCommandArgs = generateCommandArgs(
                 sourceFile.project,
                 sourceByte,
-                buildFormatArgs(stdinFileNameArgs = getStdinFileNameArgs(sourceFile)),
+                buildFormatArgs(stdinFileNameArgs = getStdinFileNameArgs(sourceFile, executable)),
                 true,
-                configPath = configPath
+                configPath = configPath,
+                executable = executable
             ) ?: return
 
             if (projectRef.isDisposed) return

--- a/src/com/koxudaxi/ruff/RuffWslUriSupport.kt
+++ b/src/com/koxudaxi/ruff/RuffWslUriSupport.kt
@@ -1,0 +1,29 @@
+package com.koxudaxi.ruff
+
+import java.net.URI
+
+private val wslHosts = setOf("wsl.localhost", "wsl$")
+
+internal fun buildWslFileUri(path: String): String? {
+    val normalizedPath = path.replace('\\', '/')
+    val host = wslHosts.firstOrNull { normalizedPath.startsWith("//$it/") } ?: return null
+    val uriPath = normalizedPath.removePrefix("//$host/").trimStart('/')
+    return "file://$host/$uriPath"
+}
+
+internal fun buildWslUncPath(fileUri: String): String? {
+    val normalizedUri = when {
+        fileUri.startsWith("file:///wsl.localhost/") -> "file://wsl.localhost/${fileUri.removePrefix("file:///wsl.localhost/")}"
+        fileUri.startsWith("file:///wsl$/") -> "file://wsl$/${fileUri.removePrefix("file:///wsl$/")}"
+        else -> fileUri
+    }
+    val uri = runCatching { URI(normalizedUri) }.getOrNull() ?: return null
+    val host = uri.host?.takeIf { it in wslHosts } ?: return null
+    val path = uri.path?.removePrefix("/") ?: return null
+    return "//$host/$path"
+}
+
+internal fun toWindowsWslUncPath(path: String): String? =
+    path.replace('\\', '/')
+        .takeIf { normalizedPath -> wslHosts.any { normalizedPath.startsWith("//$it/") } }
+        ?.replace('/', '\\')

--- a/src/com/koxudaxi/ruff/RuffWslUriSupport.kt
+++ b/src/com/koxudaxi/ruff/RuffWslUriSupport.kt
@@ -7,11 +7,26 @@ private val wslHosts = setOf("wsl.localhost", "wsl$")
 internal fun buildWslFileUri(path: String): String? {
     val normalizedPath = path.replace('\\', '/')
     val host = wslHosts.firstOrNull { normalizedPath.startsWith("//$it/") } ?: return null
-    val uriPath = normalizedPath.removePrefix("//$host/").trimStart('/')
-    return "file://$host/$uriPath"
+    val uriPath = "/${normalizedPath.removePrefix("//$host/").trimStart('/')}"
+    return runCatching {
+        when {
+            '$' in host -> "file://$host${URI(null, null, uriPath, null).rawPath}"
+            else -> URI("file", host, uriPath, null).toASCIIString()
+        }
+    }.getOrNull()
 }
 
 internal fun buildWslUncPath(fileUri: String): String? {
+    wslHosts.forEach { host ->
+        listOf("file://$host/", "file:///$host/").forEach { prefix ->
+            if (fileUri.startsWith(prefix)) {
+                val encodedPath = fileUri.removePrefix(prefix)
+                val decodedPath = runCatching { URI("file://localhost/$encodedPath").path.removePrefix("/") }
+                    .getOrDefault(encodedPath)
+                return "//$host/$decodedPath"
+            }
+        }
+    }
     val normalizedUri = when {
         fileUri.startsWith("file:///wsl.localhost/") -> "file://wsl.localhost/${fileUri.removePrefix("file:///wsl.localhost/")}"
         fileUri.startsWith("file:///wsl$/") -> "file://wsl$/${fileUri.removePrefix("file:///wsl$/")}"

--- a/src/com/koxudaxi/ruff/lsp/intellij/RuffLspServerSupportProvider.kt
+++ b/src/com/koxudaxi/ruff/lsp/intellij/RuffLspServerSupportProvider.kt
@@ -49,6 +49,10 @@ class RuffLspServerSupportProvider : LspServerSupportProvider {
                 )
             }
         } ?: return
+        RuffLoggingService.log(
+            project,
+            "Ensuring IntelliJ LSP server: mode=${descriptor.logName}, executable=${descriptor.executable.path}, diagnostics=${project.useDiagnosticFeature}"
+        )
         serverStarter.ensureServerStarted(descriptor)
     }
 }
@@ -71,17 +75,24 @@ internal fun formatInitializeParamsLog(params: InitializeParams): String {
     return "LSP initialize params: rootUri=${params.rootUri}, rootPath=${params.rootPath}, workspaceFolders=$workspaceFolders"
 }
 
+internal fun formatLspCommandLineLog(name: String, commandLine: GeneralCommandLine): String =
+    "$name command: ${commandLine.commandLineString}"
+
 @Suppress("UnstableApiUsage")
 private class RuffLspServerDescriptor(project: Project, executable: File, ruffConfig: RuffConfigService) :
     RuffLspServerDescriptorBase(project, executable, ruffConfig) {
+    override val logName: String = "IntelliJ Ruff LSP"
     private fun createBaseCommandLine(): GeneralCommandLine? =
         getGeneralCommandLine(executable, project)
 
     override fun createCommandLine(): GeneralCommandLine {
         val commandLine = createBaseCommandLine() ?: return GeneralCommandLine()
         if (ruffConfig.useRuffFormat) {
-            return commandLine.withEnvironment("RUFF_EXPERIMENTAL_FORMATTER", "1")
+            val formattedCommandLine = commandLine.withEnvironment("RUFF_EXPERIMENTAL_FORMATTER", "1")
+            RuffLoggingService.log(project, formatLspCommandLineLog(logName, formattedCommandLine))
+            return formattedCommandLine
         }
+        RuffLoggingService.log(project, formatLspCommandLineLog(logName, commandLine))
         return commandLine
     }
 }
@@ -90,6 +101,7 @@ private class RuffLspServerDescriptor(project: Project, executable: File, ruffCo
 @Suppress("UnstableApiUsage")
 abstract class RuffLspServerDescriptorBase(project: Project, val executable: File, val ruffConfig: RuffConfigService) :
     ProjectWideLspServerDescriptor(project, "Ruff") {
+    abstract val logName: String
 
     override fun isSupportedFile(file: VirtualFile) = file.isApplicableTo
     abstract override fun createCommandLine(): GeneralCommandLine
@@ -146,10 +158,13 @@ abstract class RuffLspServerDescriptorBase(project: Project, val executable: Fil
 @Suppress("UnstableApiUsage")
 private class RuffServerServerDescriptor(project: Project, executable: File, ruffConfig: RuffConfigService) :
     RuffLspServerDescriptorBase(project, executable, ruffConfig) {
+    override val logName: String = "IntelliJ Ruff server"
 
     override fun createCommandLine(): GeneralCommandLine {
         val args = project.LSP_ARGS + (getConfigArgs(ruffConfig) ?: listOf())
-        return getGeneralCommandLine(executable, project, *args.toTypedArray()) ?: GeneralCommandLine()
+        val commandLine = getGeneralCommandLine(executable, project, *args.toTypedArray()) ?: return GeneralCommandLine()
+        RuffLoggingService.log(project, formatLspCommandLineLog(logName, commandLine))
+        return commandLine
     }
 }
 

--- a/src/com/koxudaxi/ruff/lsp/intellij/RuffLspServerSupportProvider.kt
+++ b/src/com/koxudaxi/ruff/lsp/intellij/RuffLspServerSupportProvider.kt
@@ -1,5 +1,6 @@
 import com.intellij.execution.configurations.GeneralCommandLine
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.SystemInfo
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.platform.lsp.api.LspServerSupportProvider
 import com.intellij.platform.lsp.api.ProjectWideLspServerDescriptor
@@ -11,6 +12,7 @@ import com.koxudaxi.ruff.lsp.useDiagnosticFeature
 import com.koxudaxi.ruff.lsp.useFormattingFeature
 import com.koxudaxi.ruff.lsp.useHoverFeature
 import kotlinx.serialization.Serializable
+import org.eclipse.lsp4j.InitializeParams
 import java.io.File
 
 
@@ -73,6 +75,26 @@ abstract class RuffLspServerDescriptorBase(project: Project, val executable: Fil
 
     override fun isSupportedFile(file: VirtualFile) = file.extension == "py"
     abstract override fun createCommandLine(): GeneralCommandLine
+
+    override fun getFileUri(file: VirtualFile): String =
+        if (SystemInfo.isWindows) {
+            buildWslFileUri(file.path) ?: super.getFileUri(file)
+        } else {
+            super.getFileUri(file)
+        }
+
+    override fun findFileByUri(fileUri: String): VirtualFile? =
+        if (SystemInfo.isWindows) {
+            buildWslUncPath(fileUri)?.let { findLocalFileByPath(it) } ?: super.findFileByUri(fileUri)
+        } else {
+            super.findFileByUri(fileUri)
+        }
+
+    override fun createInitializeParams(): InitializeParams =
+        super.createInitializeParams().apply {
+            if (!SystemInfo.isWindows) return@apply
+            rootPath = rootPath?.let { toWindowsWslUncPath(it) } ?: rootPath
+        }
 
     override val lspHoverSupport: Boolean = project.useHoverFeature
     override val lspCodeActionsSupport: LspCodeActionsSupport? =

--- a/src/com/koxudaxi/ruff/lsp/intellij/RuffLspServerSupportProvider.kt
+++ b/src/com/koxudaxi/ruff/lsp/intellij/RuffLspServerSupportProvider.kt
@@ -2,7 +2,10 @@ import com.intellij.execution.configurations.GeneralCommandLine
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.SystemInfo
 import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.platform.lsp.api.Lsp4jClient
 import com.intellij.platform.lsp.api.LspServerSupportProvider
+import com.intellij.platform.lsp.api.LspServerListener
+import com.intellij.platform.lsp.api.LspServerNotificationsHandler
 import com.intellij.platform.lsp.api.ProjectWideLspServerDescriptor
 import com.intellij.platform.lsp.api.customization.*
 import com.koxudaxi.ruff.*
@@ -12,7 +15,10 @@ import com.koxudaxi.ruff.lsp.useDiagnosticFeature
 import com.koxudaxi.ruff.lsp.useFormattingFeature
 import com.koxudaxi.ruff.lsp.useHoverFeature
 import kotlinx.serialization.Serializable
+import org.eclipse.lsp4j.InitializeResult
 import org.eclipse.lsp4j.InitializeParams
+import org.eclipse.lsp4j.MessageParams
+import org.eclipse.lsp4j.PublishDiagnosticsParams
 import java.io.File
 
 
@@ -51,7 +57,7 @@ class RuffLspServerSupportProvider : LspServerSupportProvider {
         } ?: return
         RuffLoggingService.log(
             project,
-            "Ensuring IntelliJ LSP server: mode=${descriptor.logName}, executable=${descriptor.executable.path}, diagnostics=${project.useDiagnosticFeature}"
+            "Ensuring IntelliJ LSP server: mode=${descriptor.logName}, executable=${descriptor.executable.path}, diagnostics=${project.useDiagnosticFeature}, formatting=${project.useFormattingFeature}, hover=${project.useHoverFeature}, codeActions=${project.useCodeActionFeature}"
         )
         serverStarter.ensureServerStarted(descriptor)
     }
@@ -77,6 +83,27 @@ internal fun formatInitializeParamsLog(params: InitializeParams): String {
 
 internal fun formatLspCommandLineLog(name: String, commandLine: GeneralCommandLine): String =
     "$name command: ${commandLine.commandLineString}"
+
+internal fun formatInitializeResultLog(result: InitializeResult): String {
+    val capabilities = result.capabilities
+    val diagnosticProvider = capabilities.diagnosticProvider != null
+    val syncKind = capabilities.textDocumentSync?.left ?: capabilities.textDocumentSync?.right?.change
+    val hoverProvider = capabilities.hoverProvider?.left ?: capabilities.hoverProvider
+    val codeActionProvider = capabilities.codeActionProvider?.left ?: capabilities.codeActionProvider
+    val documentFormattingProvider =
+        capabilities.documentFormattingProvider?.left ?: capabilities.documentFormattingProvider
+    val documentRangeFormattingProvider =
+        capabilities.documentRangeFormattingProvider?.left ?: capabilities.documentRangeFormattingProvider
+    return "LSP initialize result: diagnosticProvider=$diagnosticProvider, textDocumentSync=$syncKind, hoverProvider=$hoverProvider, codeActionProvider=$codeActionProvider, documentFormattingProvider=$documentFormattingProvider, documentRangeFormattingProvider=$documentRangeFormattingProvider"
+}
+
+internal fun formatPublishDiagnosticsLog(params: PublishDiagnosticsParams): String =
+    "LSP publish diagnostics: uri=${params.uri}, count=${params.diagnostics?.size ?: 0}, version=${params.version}"
+
+internal fun formatServerMessageLog(prefix: String, params: MessageParams): String =
+    "$prefix: type=${params.type}, message=${params.message}"
+
+private fun shouldLogWindowsLspDetails(): Boolean = SystemInfo.isWindows
 
 @Suppress("UnstableApiUsage")
 private class RuffLspServerDescriptor(project: Project, executable: File, ruffConfig: RuffConfigService) :
@@ -140,6 +167,38 @@ abstract class RuffLspServerDescriptorBase(project: Project, val executable: Fil
         return params
     }
 
+    override fun createLsp4jClient(serverNotificationsHandler: LspServerNotificationsHandler): Lsp4jClient {
+        if (!SystemInfo.isWindows) {
+            return super.createLsp4jClient(serverNotificationsHandler)
+        }
+        return Lsp4jClient(
+            LoggingLspServerNotificationsHandler(
+                project,
+                serverNotificationsHandler
+            )
+        )
+    }
+
+    override val lspServerListener: LspServerListener
+        get() {
+            if (!SystemInfo.isWindows) {
+                return super.lspServerListener ?: object : LspServerListener {}
+            }
+            return object : LspServerListener {
+            override fun serverInitialized(params: InitializeResult) {
+                if (shouldLogWindowsLspDetails()) {
+                    RuffLoggingService.log(project, formatInitializeResultLog(params))
+                }
+            }
+
+            override fun serverStopped(unexpected: Boolean) {
+                if (shouldLogWindowsLspDetails()) {
+                    RuffLoggingService.log(project, "LSP server stopped: unexpected=$unexpected")
+                }
+            }
+        }
+        }
+
     override val lspHoverSupport: Boolean = project.useHoverFeature
     override val lspCodeActionsSupport: LspCodeActionsSupport? =
         if (project.useCodeActionFeature) RuffLspCodeActionsSupport(project) else null
@@ -178,3 +237,36 @@ data class Settings(
 data class InitOptions(
     val settings: Settings
 )
+
+private class LoggingLspServerNotificationsHandler(
+    private val project: Project,
+    private val delegate: LspServerNotificationsHandler
+) : LspServerNotificationsHandler by delegate {
+    override fun publishDiagnostics(params: PublishDiagnosticsParams) {
+        if (shouldLogWindowsLspDetails()) {
+            RuffLoggingService.log(project, formatPublishDiagnosticsLog(params))
+        }
+        delegate.publishDiagnostics(params)
+    }
+
+    override fun logMessage(params: MessageParams) {
+        if (shouldLogWindowsLspDetails()) {
+            RuffLoggingService.log(project, formatServerMessageLog("LSP log message", params))
+        }
+        delegate.logMessage(params)
+    }
+
+    override fun showMessage(params: MessageParams) {
+        if (shouldLogWindowsLspDetails()) {
+            RuffLoggingService.log(project, formatServerMessageLog("LSP show message", params))
+        }
+        delegate.showMessage(params)
+    }
+
+    override fun refreshDiagnostics() =
+        delegate.refreshDiagnostics().also {
+            if (shouldLogWindowsLspDetails()) {
+                RuffLoggingService.log(project, "LSP requested diagnostic refresh")
+            }
+        }
+}

--- a/src/com/koxudaxi/ruff/lsp/intellij/RuffLspServerSupportProvider.kt
+++ b/src/com/koxudaxi/ruff/lsp/intellij/RuffLspServerSupportProvider.kt
@@ -57,7 +57,7 @@ class RuffLspServerSupportProvider : LspServerSupportProvider {
         } ?: return
         RuffLoggingService.log(
             project,
-            "Ensuring IntelliJ LSP server: mode=${descriptor.logName}, executable=${descriptor.executable.path}, diagnostics=${project.useDiagnosticFeature}, formatting=${project.useFormattingFeature}, hover=${project.useHoverFeature}, codeActions=${project.useCodeActionFeature}"
+            "Ensuring IntelliJ LSP server: mode=${descriptor.logName}, executable=${descriptor.executable.path}, diagnostics=${project.useDiagnosticFeature}, formatting=${project.useFormattingFeature}, hover=${project.useHoverFeature}, codeActions=${project.useCodeActionFeature}, diagnosticsCustomizer=${descriptor.lspCustomization.diagnosticsCustomizer::class.simpleName}"
         )
         serverStarter.ensureServerStarted(descriptor)
     }
@@ -106,6 +106,46 @@ internal fun formatServerMessageLog(prefix: String, params: MessageParams): Stri
 private fun shouldLogWindowsLspDetails(): Boolean = SystemInfo.isWindows
 
 @Suppress("UnstableApiUsage")
+internal fun createRuffLspCustomization(project: Project): LspCustomization =
+    object : LspCustomization() {
+        override val goToDefinitionCustomizer: LspGoToDefinitionCustomizer =
+            LspGoToDefinitionDisabled
+
+        override val goToTypeDefinitionCustomizer: LspGoToTypeDefinitionCustomizer =
+            LspGoToTypeDefinitionDisabled
+
+        override val hoverCustomizer: LspHoverCustomizer =
+            if (project.useHoverFeature) LspHoverSupport() else LspHoverDisabled
+
+        override val completionCustomizer: LspCompletionCustomizer =
+            LspCompletionDisabled
+
+        override val semanticTokensCustomizer: LspSemanticTokensCustomizer =
+            LspSemanticTokensDisabled
+
+        override val diagnosticsCustomizer: LspDiagnosticsCustomizer =
+            if (project.useDiagnosticFeature) RuffLspDiagnosticsSupport(project) else LspDiagnosticsDisabled
+
+        override val codeActionsCustomizer: LspCodeActionsCustomizer =
+            if (project.useCodeActionFeature) RuffLspCodeActionsSupport(project) else LspCodeActionsDisabled
+
+        override val commandsCustomizer: LspCommandsCustomizer =
+            LspCommandsSupport()
+
+        override val formattingCustomizer: LspFormattingCustomizer =
+            if (project.useFormattingFeature) RuffLspFormattingSupport(project) else LspFormattingDisabled
+
+        override val findReferencesCustomizer: LspFindReferencesCustomizer =
+            LspFindReferencesDisabled
+
+        override val documentColorCustomizer: LspDocumentColorCustomizer =
+            LspDocumentColorDisabled
+
+        override val documentLinkCustomizer: LspDocumentLinkCustomizer =
+            LspDocumentLinkDisabled
+    }
+
+@Suppress("UnstableApiUsage")
 private class RuffLspServerDescriptor(project: Project, executable: File, ruffConfig: RuffConfigService) :
     RuffLspServerDescriptorBase(project, executable, ruffConfig) {
     override val logName: String = "IntelliJ Ruff LSP"
@@ -129,6 +169,9 @@ private class RuffLspServerDescriptor(project: Project, executable: File, ruffCo
 abstract class RuffLspServerDescriptorBase(project: Project, val executable: File, val ruffConfig: RuffConfigService) :
     ProjectWideLspServerDescriptor(project, "Ruff") {
     abstract val logName: String
+    private val ruffLspCustomization: LspCustomization by lazy(LazyThreadSafetyMode.NONE) {
+        createRuffLspCustomization(project)
+    }
 
     override fun isSupportedFile(file: VirtualFile) = file.isApplicableTo
     abstract override fun createCommandLine(): GeneralCommandLine
@@ -199,17 +242,8 @@ abstract class RuffLspServerDescriptorBase(project: Project, val executable: Fil
         }
         }
 
-    override val lspHoverSupport: Boolean = project.useHoverFeature
-    override val lspCodeActionsSupport: LspCodeActionsSupport? =
-        if (project.useCodeActionFeature) RuffLspCodeActionsSupport(project) else null
-    override val lspFormattingSupport: LspFormattingSupport? =
-        if (project.useFormattingFeature) RuffLspFormattingSupport(project) else null
-    override val lspCommandsSupport: LspCommandsSupport = LspCommandsSupport()
-    override val lspDiagnosticsSupport: LspDiagnosticsSupport? =
-        if (project.useDiagnosticFeature) RuffLspDiagnosticsSupport(project) else null
-
-    override val lspGoToDefinitionSupport: Boolean = false
-    override val lspCompletionSupport: LspCompletionSupport? = null
+    override val lspCustomization: LspCustomization
+        get() = ruffLspCustomization
 
 
 }

--- a/src/com/koxudaxi/ruff/lsp/intellij/RuffLspServerSupportProvider.kt
+++ b/src/com/koxudaxi/ruff/lsp/intellij/RuffLspServerSupportProvider.kt
@@ -53,6 +53,24 @@ class RuffLspServerSupportProvider : LspServerSupportProvider {
     }
 }
 
+internal fun resolveWslLspFileUri(path: String, fallbackUri: String): String =
+    buildWslFileUri(path) ?: fallbackUri
+
+internal fun resolveWslLspLocalPath(fileUri: String): String? =
+    buildWslUncPath(fileUri)
+
+internal fun normalizeWslInitializeParams(params: InitializeParams): InitializeParams =
+    params.apply {
+        rootPath = rootPath?.let { toWindowsWslUncPath(it) } ?: rootPath
+    }
+
+internal fun formatInitializeParamsLog(params: InitializeParams): String {
+    val workspaceFolders = params.workspaceFolders
+        ?.joinToString(prefix = "[", postfix = "]") { "{name=${it.name}, uri=${it.uri}}" }
+        ?: "[]"
+    return "LSP initialize params: rootUri=${params.rootUri}, rootPath=${params.rootPath}, workspaceFolders=$workspaceFolders"
+}
+
 @Suppress("UnstableApiUsage")
 private class RuffLspServerDescriptor(project: Project, executable: File, ruffConfig: RuffConfigService) :
     RuffLspServerDescriptorBase(project, executable, ruffConfig) {
@@ -76,25 +94,39 @@ abstract class RuffLspServerDescriptorBase(project: Project, val executable: Fil
     override fun isSupportedFile(file: VirtualFile) = file.isApplicableTo
     abstract override fun createCommandLine(): GeneralCommandLine
 
-    override fun getFileUri(file: VirtualFile): String =
-        if (SystemInfo.isWindows) {
-            buildWslFileUri(file.path) ?: super.getFileUri(file)
-        } else {
-            super.getFileUri(file)
+    override fun getFileUri(file: VirtualFile): String {
+        val fallbackUri = super.getFileUri(file)
+        if (!SystemInfo.isWindows) {
+            return fallbackUri
         }
+        val resolvedUri = resolveWslLspFileUri(file.path, fallbackUri)
+        if (resolvedUri != fallbackUri) {
+            RuffLoggingService.log(project, "LSP file URI: ${file.path} -> $resolvedUri")
+        }
+        return resolvedUri
+    }
 
-    override fun findFileByUri(fileUri: String): VirtualFile? =
-        if (SystemInfo.isWindows) {
-            buildWslUncPath(fileUri)?.let { findLocalFileByPath(it) } ?: super.findFileByUri(fileUri)
-        } else {
-            super.findFileByUri(fileUri)
+    override fun findFileByUri(fileUri: String): VirtualFile? {
+        if (!SystemInfo.isWindows) {
+            return super.findFileByUri(fileUri)
         }
+        val resolvedPath = resolveWslLspLocalPath(fileUri)
+        if (resolvedPath != null) {
+            RuffLoggingService.log(project, "LSP resolve URI: $fileUri -> $resolvedPath")
+            return findLocalFileByPath(resolvedPath)
+        }
+        return super.findFileByUri(fileUri)
+    }
 
-    override fun createInitializeParams(): InitializeParams =
-        super.createInitializeParams().apply {
-            if (!SystemInfo.isWindows) return@apply
-            rootPath = rootPath?.let { toWindowsWslUncPath(it) } ?: rootPath
+    override fun createInitializeParams(): InitializeParams {
+        val params = super.createInitializeParams()
+        if (!SystemInfo.isWindows) {
+            return params
         }
+        normalizeWslInitializeParams(params)
+        RuffLoggingService.log(project, formatInitializeParamsLog(params))
+        return params
+    }
 
     override val lspHoverSupport: Boolean = project.useHoverFeature
     override val lspCodeActionsSupport: LspCodeActionsSupport? =

--- a/src/com/koxudaxi/ruff/lsp/intellij/supports/RuffLspDiagnosticsSupport.kt
+++ b/src/com/koxudaxi/ruff/lsp/intellij/supports/RuffLspDiagnosticsSupport.kt
@@ -1,8 +1,48 @@
 package com.koxudaxi.ruff.lsp.intellij.supports
 
+import com.intellij.codeInsight.intention.IntentionAction
+import com.intellij.lang.annotation.AnnotationHolder
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.SystemInfo
+import com.intellij.openapi.util.TextRange
+import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.platform.lsp.api.customization.LspDiagnosticsSupport
+import com.koxudaxi.ruff.RuffLoggingService
+import com.koxudaxi.ruff.buildWslFileUri
+import org.eclipse.lsp4j.Diagnostic
 
 
 @Suppress("UnstableApiUsage")
-class RuffLspDiagnosticsSupport(val project: Project) : LspDiagnosticsSupport()
+class RuffLspDiagnosticsSupport(private val project: Project) : LspDiagnosticsSupport() {
+    override fun shouldAskServerForDiagnostics(file: VirtualFile): Boolean {
+        val shouldAsk = super.shouldAskServerForDiagnostics(file)
+        if (shouldLogWindowsWslDiagnostics(file)) {
+            RuffLoggingService.log(
+                project,
+                "LSP pull diagnostics enabled: file=${file.path}, uri=${buildWslFileUri(file.path) ?: file.path}"
+            )
+        }
+        return shouldAsk
+    }
+
+    override fun createAnnotation(
+        holder: AnnotationHolder,
+        diagnostic: Diagnostic,
+        textRange: TextRange,
+        quickFixes: List<IntentionAction>
+    ) {
+        if (shouldLogWindowsWslDiagnostics(diagnostic)) {
+            RuffLoggingService.log(
+                project,
+                "LSP diagnostic annotation: code=${diagnostic.code?.left ?: diagnostic.code?.right}, message=${diagnostic.message}, range=${textRange.startOffset}-${textRange.endOffset}"
+            )
+        }
+        super.createAnnotation(holder, diagnostic, textRange, quickFixes)
+    }
+
+    private fun shouldLogWindowsWslDiagnostics(file: VirtualFile): Boolean =
+        SystemInfo.isWindows && buildWslFileUri(file.path) != null
+
+    private fun shouldLogWindowsWslDiagnostics(diagnostic: Diagnostic): Boolean =
+        SystemInfo.isWindows && diagnostic.source == "Ruff"
+}

--- a/src/com/koxudaxi/ruff/lsp/lsp4ij/RuffLanguageClient.kt
+++ b/src/com/koxudaxi/ruff/lsp/lsp4ij/RuffLanguageClient.kt
@@ -3,4 +3,4 @@ package com.koxudaxi.ruff.lsp.lsp4ij
 import com.intellij.openapi.project.Project
 import com.redhat.devtools.lsp4ij.client.LanguageClientImpl
 
-class RuffLanguageClient(project: Project?) : LanguageClientImpl(project)
+class RuffLanguageClient(project: Project) : LanguageClientImpl(project)

--- a/src/com/koxudaxi/ruff/lsp/lsp4ij/RuffLanguageServerFactory.kt
+++ b/src/com/koxudaxi/ruff/lsp/lsp4ij/RuffLanguageServerFactory.kt
@@ -32,19 +32,12 @@ class RuffLanguageServerFactory : LanguageServerFactory, LanguageServerEnablemen
 
             val ruffConfigService = project.configService
             if (!ruffConfigService.enableLsp) {
-                RuffLoggingService.log(project, "LSP not enabled in config", ConsoleViewContentType.NORMAL_OUTPUT)
                 return false
             }
             if (!ruffConfigService.useRuffLsp && !ruffConfigService.useRuffServer) {
-                RuffLoggingService.log(
-                    project,
-                    "Neither Ruff LSP nor Server enabled",
-                    ConsoleViewContentType.NORMAL_OUTPUT
-                )
                 return false
             }
             if (!ruffConfigService.useLsp4ij) {
-                RuffLoggingService.log(project, "LSP4IJ not enabled in config", ConsoleViewContentType.NORMAL_OUTPUT)
                 return false
             }
             if (!isInspectionEnabled(project)) {

--- a/testSrc/RuffLspServerSupportProviderTest.kt
+++ b/testSrc/RuffLspServerSupportProviderTest.kt
@@ -1,9 +1,17 @@
 import com.intellij.execution.configurations.GeneralCommandLine
+import com.intellij.openapi.util.SystemInfo
+import com.intellij.testFramework.LightVirtualFile
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
 import com.koxudaxi.ruff.RuffConfigService
+import com.koxudaxi.ruff.lsp.intellij.supports.RuffLspDiagnosticsSupport
 import kotlin.io.path.createTempFile
+import org.eclipse.lsp4j.DiagnosticRegistrationOptions
 import org.eclipse.lsp4j.InitializeParams
+import org.eclipse.lsp4j.InitializeResult
+import org.eclipse.lsp4j.PublishDiagnosticsParams
+import org.eclipse.lsp4j.ServerCapabilities
 import org.eclipse.lsp4j.WorkspaceFolder
+import org.eclipse.lsp4j.jsonrpc.messages.Either
 
 class RuffLspServerSupportProviderTest : BasePlatformTestCase() {
     fun testSupportsPythonStubFiles() {
@@ -64,6 +72,56 @@ class RuffLspServerSupportProviderTest : BasePlatformTestCase() {
         )
     }
 
+    fun testFormatsInitializeResultLog() {
+        val result = InitializeResult(
+            ServerCapabilities().apply {
+                diagnosticProvider = DiagnosticRegistrationOptions()
+                hoverProvider = Either.forLeft(true)
+                codeActionProvider = Either.forLeft(true)
+                documentFormattingProvider = Either.forLeft(true)
+                documentRangeFormattingProvider = Either.forLeft(true)
+            }
+        )
+
+        assertEquals(
+            "LSP initialize result: diagnosticProvider=true, textDocumentSync=null, hoverProvider=true, codeActionProvider=true, documentFormattingProvider=true, documentRangeFormattingProvider=true",
+            formatInitializeResultLog(result)
+        )
+    }
+
+    fun testFormatsPublishDiagnosticsLog() {
+        val params = PublishDiagnosticsParams().apply {
+            uri = "file://wsl.localhost/Ubuntu/home/test/project/main.py"
+            version = 3
+            diagnostics = emptyList()
+        }
+
+        assertEquals(
+            "LSP publish diagnostics: uri=file://wsl.localhost/Ubuntu/home/test/project/main.py, count=0, version=3",
+            formatPublishDiagnosticsLog(params)
+        )
+    }
+
+    fun testWindowsWslLspUsesWslDocumentUriAndPullDiagnostics() {
+        if (!SystemInfo.isWindows) return
+
+        val executable = createTempFile("ruff", ".tmp").toFile().apply { deleteOnExit() }
+        val descriptor = TestRuffLspServerDescriptor(
+            project,
+            executable,
+            RuffConfigService.getInstance(project)
+        )
+        val file = WslLightVirtualFile("//wsl.localhost/Ubuntu/home/test/project/main.py")
+
+        assertEquals(
+            "file://wsl.localhost/Ubuntu/home/test/project/main.py",
+            descriptor.getFileUri(file)
+        )
+
+        val diagnosticsSupport = descriptor.lspDiagnosticsSupport as RuffLspDiagnosticsSupport
+        assertTrue(diagnosticsSupport.shouldAskServerForDiagnostics(file))
+    }
+
     private class TestRuffLspServerDescriptor(
         project: com.intellij.openapi.project.Project,
         executable: java.io.File,
@@ -71,5 +129,11 @@ class RuffLspServerSupportProviderTest : BasePlatformTestCase() {
     ) : RuffLspServerDescriptorBase(project, executable, ruffConfig) {
         override val logName: String = "test"
         override fun createCommandLine(): GeneralCommandLine = GeneralCommandLine()
+    }
+
+    private class WslLightVirtualFile(private val wslPath: String) :
+        LightVirtualFile(wslPath.substringAfterLast('/'), "") {
+        override fun getPath(): String = wslPath
+        override fun getPresentableUrl(): String = wslPath
     }
 }

--- a/testSrc/RuffLspServerSupportProviderTest.kt
+++ b/testSrc/RuffLspServerSupportProviderTest.kt
@@ -4,6 +4,7 @@ import com.intellij.testFramework.LightVirtualFile
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
 import com.koxudaxi.ruff.RuffConfigService
 import com.koxudaxi.ruff.lsp.intellij.supports.RuffLspDiagnosticsSupport
+import com.intellij.platform.lsp.api.customization.LspDiagnosticsDisabled
 import kotlin.io.path.createTempFile
 import org.eclipse.lsp4j.DiagnosticRegistrationOptions
 import org.eclipse.lsp4j.InitializeParams
@@ -118,8 +119,15 @@ class RuffLspServerSupportProviderTest : BasePlatformTestCase() {
             descriptor.getFileUri(file)
         )
 
-        val diagnosticsSupport = descriptor.lspDiagnosticsSupport as RuffLspDiagnosticsSupport
+        val diagnosticsSupport = descriptor.lspCustomization.diagnosticsCustomizer as RuffLspDiagnosticsSupport
         assertTrue(diagnosticsSupport.shouldAskServerForDiagnostics(file))
+    }
+
+    fun testCreatesRuffLspCustomizationForBuiltInClient() {
+        val diagnosticsCustomizer = createRuffLspCustomization(project).diagnosticsCustomizer
+
+        assertTrue(diagnosticsCustomizer is RuffLspDiagnosticsSupport)
+        assertFalse(diagnosticsCustomizer is LspDiagnosticsDisabled)
     }
 
     private class TestRuffLspServerDescriptor(

--- a/testSrc/RuffLspServerSupportProviderTest.kt
+++ b/testSrc/RuffLspServerSupportProviderTest.kt
@@ -2,6 +2,8 @@ import com.intellij.execution.configurations.GeneralCommandLine
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
 import com.koxudaxi.ruff.RuffConfigService
 import kotlin.io.path.createTempFile
+import org.eclipse.lsp4j.InitializeParams
+import org.eclipse.lsp4j.WorkspaceFolder
 
 class RuffLspServerSupportProviderTest : BasePlatformTestCase() {
     fun testSupportsPythonStubFiles() {
@@ -15,6 +17,51 @@ class RuffLspServerSupportProviderTest : BasePlatformTestCase() {
         val stubFile = myFixture.configureByText("example.pyi", "value: int\n").virtualFile
 
         assertTrue(descriptor.isSupportedFile(stubFile))
+    }
+
+    fun testResolvesWslLspFileUri() {
+        assertEquals(
+            "file://wsl.localhost/Ubuntu/home/test/project",
+            resolveWslLspFileUri("""\\wsl.localhost\Ubuntu\home\test\project""", "file:///fallback")
+        )
+    }
+
+    fun testResolvesWslLspLocalPath() {
+        assertEquals(
+            "//wsl.localhost/Ubuntu/home/test/project",
+            resolveWslLspLocalPath("file://wsl.localhost/Ubuntu/home/test/project")
+        )
+    }
+
+    fun testNormalizeWslInitializeParamsKeepsUrisAndConvertsRootPath() {
+        val params = InitializeParams().apply {
+            rootUri = "file://wsl.localhost/Ubuntu/home/test/project"
+            rootPath = "//wsl.localhost/Ubuntu/home/test/project"
+            workspaceFolders = listOf(
+                WorkspaceFolder("file://wsl.localhost/Ubuntu/home/test/project", "project")
+            )
+        }
+
+        normalizeWslInitializeParams(params)
+
+        assertEquals("""\\wsl.localhost\Ubuntu\home\test\project""", params.rootPath)
+        assertEquals("file://wsl.localhost/Ubuntu/home/test/project", params.rootUri)
+        assertEquals("file://wsl.localhost/Ubuntu/home/test/project", params.workspaceFolders.single().uri)
+    }
+
+    fun testFormatsInitializeParamsLog() {
+        val params = InitializeParams().apply {
+            rootUri = "file://wsl.localhost/Ubuntu/home/test/project"
+            rootPath = """\\wsl.localhost\Ubuntu\home\test\project"""
+            workspaceFolders = listOf(
+                WorkspaceFolder("file://wsl.localhost/Ubuntu/home/test/project", "project")
+            )
+        }
+
+        assertEquals(
+            "LSP initialize params: rootUri=file://wsl.localhost/Ubuntu/home/test/project, rootPath=\\\\wsl.localhost\\Ubuntu\\home\\test\\project, workspaceFolders=[{name=project, uri=file://wsl.localhost/Ubuntu/home/test/project}]",
+            formatInitializeParamsLog(params)
+        )
     }
 
     private class TestRuffLspServerDescriptor(

--- a/testSrc/RuffLspServerSupportProviderTest.kt
+++ b/testSrc/RuffLspServerSupportProviderTest.kt
@@ -69,6 +69,7 @@ class RuffLspServerSupportProviderTest : BasePlatformTestCase() {
         executable: java.io.File,
         ruffConfig: RuffConfigService
     ) : RuffLspServerDescriptorBase(project, executable, ruffConfig) {
+        override val logName: String = "test"
         override fun createCommandLine(): GeneralCommandLine = GeneralCommandLine()
     }
 }

--- a/testSrc/com/koxudaxi/ruff/RuffStdinFilenameArgsTest.kt
+++ b/testSrc/com/koxudaxi/ruff/RuffStdinFilenameArgsTest.kt
@@ -1,0 +1,45 @@
+package com.koxudaxi.ruff
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class RuffStdinFilenameArgsTest {
+    @Test
+    fun `uses WSL path when Ruff runs inside WSL`() {
+        assertEquals(
+            "/home/test/project/main.py",
+            resolveStdinFileName(
+                "//wsl.localhost/Ubuntu/home/test/project/main.py",
+                "main.py",
+                true,
+                "/home/test/project/main.py"
+            )
+        )
+    }
+
+    @Test
+    fun `uses UNC path when windows Ruff handles a local WSL project`() {
+        assertEquals(
+            """\\wsl.localhost\Ubuntu\home\test\project\main.py""",
+            resolveStdinFileName(
+                "//wsl.localhost/Ubuntu/home/test/project/main.py",
+                "main.py",
+                false,
+                "/home/test/project/main.py"
+            )
+        )
+    }
+
+    @Test
+    fun `keeps project relative paths for non WSL files`() {
+        assertEquals(
+            "src/main.py",
+            resolveStdinFileName(
+                "/Users/test/project/src/main.py",
+                "src/main.py",
+                false,
+                null
+            )
+        )
+    }
+}

--- a/testSrc/com/koxudaxi/ruff/RuffStdinFilenameArgsTest.kt
+++ b/testSrc/com/koxudaxi/ruff/RuffStdinFilenameArgsTest.kt
@@ -18,6 +18,19 @@ class RuffStdinFilenameArgsTest {
     }
 
     @Test
+    fun `falls back to project relative path when WSL path resolution fails`() {
+        assertEquals(
+            "main.py",
+            resolveStdinFileName(
+                "//wsl.localhost/Ubuntu/home/test/project/main.py",
+                "main.py",
+                true,
+                null
+            )
+        )
+    }
+
+    @Test
     fun `uses UNC path when windows Ruff handles a local WSL project`() {
         assertEquals(
             """\\wsl.localhost\Ubuntu\home\test\project\main.py""",

--- a/testSrc/com/koxudaxi/ruff/RuffWslUriSupportTest.kt
+++ b/testSrc/com/koxudaxi/ruff/RuffWslUriSupportTest.kt
@@ -1,0 +1,54 @@
+package com.koxudaxi.ruff
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class RuffWslUriSupportTest {
+    @Test
+    fun `builds a WSL file URI from a system independent UNC path`() {
+        assertEquals(
+            "file://wsl.localhost/Ubuntu/home/test/project",
+            buildWslFileUri("//wsl.localhost/Ubuntu/home/test/project")
+        )
+    }
+
+    @Test
+    fun `builds a WSL file URI from a windows UNC path`() {
+        assertEquals(
+            "file://wsl.localhost/Ubuntu/home/test/project",
+            buildWslFileUri("""\\wsl.localhost\Ubuntu\home\test\project""")
+        )
+    }
+
+    @Test
+    fun `converts a WSL file URI back to a UNC path`() {
+        assertEquals(
+            "//wsl.localhost/Ubuntu/home/test/project",
+            buildWslUncPath("file://wsl.localhost/Ubuntu/home/test/project")
+        )
+    }
+
+    @Test
+    fun `converts an authority-less WSL file URI back to a UNC path`() {
+        assertEquals(
+            "//wsl.localhost/Ubuntu/home/test/project",
+            buildWslUncPath("file:///wsl.localhost/Ubuntu/home/test/project")
+        )
+    }
+
+    @Test
+    fun `converts a system independent WSL path to a windows UNC path`() {
+        assertEquals(
+            """\\wsl.localhost\Ubuntu\home\test\project""",
+            toWindowsWslUncPath("//wsl.localhost/Ubuntu/home/test/project")
+        )
+    }
+
+    @Test
+    fun `ignores non WSL paths`() {
+        assertNull(buildWslFileUri("/tmp/project"))
+        assertNull(buildWslUncPath("file:///tmp/project"))
+        assertNull(toWindowsWslUncPath("/tmp/project"))
+    }
+}

--- a/testSrc/com/koxudaxi/ruff/RuffWslUriSupportTest.kt
+++ b/testSrc/com/koxudaxi/ruff/RuffWslUriSupportTest.kt
@@ -46,6 +46,23 @@ class RuffWslUriSupportTest {
     }
 
     @Test
+    fun `builds and restores URI for wsl dollar host`() {
+        val uncPath = """\\wsl$\Ubuntu\home\test\project"""
+        val fileUri = "file://wsl$/Ubuntu/home/test/project"
+        assertEquals(fileUri, buildWslFileUri(uncPath))
+        assertEquals("//wsl$/Ubuntu/home/test/project", buildWslUncPath(fileUri))
+        assertEquals(uncPath, toWindowsWslUncPath("//wsl$/Ubuntu/home/test/project"))
+    }
+
+    @Test
+    fun `escapes URI segments and decodes them when converting back`() {
+        val uncPath = """\\wsl.localhost\Ubuntu\home\test\My Project"""
+        val fileUri = "file://wsl.localhost/Ubuntu/home/test/My%20Project"
+        assertEquals(fileUri, buildWslFileUri(uncPath))
+        assertEquals("//wsl.localhost/Ubuntu/home/test/My Project", buildWslUncPath(fileUri))
+    }
+
+    @Test
     fun `ignores non WSL paths`() {
         assertNull(buildWslFileUri("/tmp/project"))
         assertNull(buildWslUncPath("file:///tmp/project"))


### PR DESCRIPTION
Fixes: #627

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Ruff server startup failures for local WSL projects on Windows.

* **Improvements**
  * Better WSL/Windows path and URI handling so files resolve correctly during initialization, linting and formatting.
  * Formatting and background runs now consistently resolve and reuse the Ruff executable.
  * Improved startup and command-line logging for server diagnostics.

* **Tests**
  * Added unit tests for WSL path/URI conversions, percent-encoding, stdin filename resolution, and non-WSL fallbacks.

* **Documentation**
  * Added an unreleased changelog entry documenting the WSL startup fix.

* **Chores**
  * Added CI job to run Windows/WSL-path tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->