### PR TITLE
Support formatting Python stub files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Support formatting Python stub files
+
 ## [0.0.52] - 2025-12-15
 
 - Fix: add --stdin-filename to format command for config auto-discovery [[#651](https://github.com/koxudaxi/ruff-pycharm-plugin/pull/651)]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-- Support formatting Python stub files
+- Support formatting Python stub files [[#672](https://github.com/koxudaxi/ruff-pycharm-plugin/pull/672)]
 
 ## [0.0.52] - 2025-12-15
 

--- a/src/com/koxudaxi/ruff/lsp/intellij/RuffLspServerSupportProvider.kt
+++ b/src/com/koxudaxi/ruff/lsp/intellij/RuffLspServerSupportProvider.kt
@@ -71,7 +71,7 @@ private class RuffLspServerDescriptor(project: Project, executable: File, ruffCo
 abstract class RuffLspServerDescriptorBase(project: Project, val executable: File, val ruffConfig: RuffConfigService) :
     ProjectWideLspServerDescriptor(project, "Ruff") {
 
-    override fun isSupportedFile(file: VirtualFile) = file.extension == "py"
+    override fun isSupportedFile(file: VirtualFile) = file.isApplicableTo
     abstract override fun createCommandLine(): GeneralCommandLine
 
     override val lspHoverSupport: Boolean = project.useHoverFeature

--- a/testSrc/RuffLspServerSupportProviderTest.kt
+++ b/testSrc/RuffLspServerSupportProviderTest.kt
@@ -1,0 +1,27 @@
+import com.intellij.execution.configurations.GeneralCommandLine
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import com.koxudaxi.ruff.RuffConfigService
+import kotlin.io.path.createTempFile
+
+class RuffLspServerSupportProviderTest : BasePlatformTestCase() {
+    fun testSupportsPythonStubFiles() {
+        val executable = createTempFile("ruff", ".tmp").toFile().apply { deleteOnExit() }
+        val descriptor = TestRuffLspServerDescriptor(
+            project,
+            executable,
+            RuffConfigService.getInstance(project)
+        )
+
+        val stubFile = myFixture.configureByText("example.pyi", "value: int\n").virtualFile
+
+        assertTrue(descriptor.isSupportedFile(stubFile))
+    }
+
+    private class TestRuffLspServerDescriptor(
+        project: com.intellij.openapi.project.Project,
+        executable: java.io.File,
+        ruffConfig: RuffConfigService
+    ) : RuffLspServerDescriptorBase(project, executable, ruffConfig) {
+        override fun createCommandLine(): GeneralCommandLine = GeneralCommandLine()
+    }
+}


### PR DESCRIPTION
Fixes: #624

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended Ruff LSP server to support Python stub files (.pyi) in addition to standard Python files.

* **Tests**
  * Added test coverage for Python stub file support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->