### PR TITLE
Enable unified PyCharm LSP support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Fix native Ruff support notification dismissal to persist per machine [[#667](https://github.com/koxudaxi/ruff-pycharm-plugin/pull/667)]
 - Support 2026.1 [[#671](https://github.com/koxudaxi/ruff-pycharm-plugin/pull/671)]
 - Check IntelliJ LSP provider registration before enabling native client [[#675](https://github.com/koxudaxi/ruff-pycharm-plugin/pull/675)]
-- Enable JetBrains LSP client support in unified PyCharm free mode
+- Enable JetBrains LSP client support in unified PyCharm free mode [[#676](https://github.com/koxudaxi/ruff-pycharm-plugin/pull/676)]
 
 ## [0.0.52] - 2025-12-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fix native Ruff support notification dismissal to persist per machine [[#667](https://github.com/koxudaxi/ruff-pycharm-plugin/pull/667)]
 - Support 2026.1 [[#671](https://github.com/koxudaxi/ruff-pycharm-plugin/pull/671)]
 - Check IntelliJ LSP provider registration before enabling native client [[#675](https://github.com/koxudaxi/ruff-pycharm-plugin/pull/675)]
+- Enable JetBrains LSP client support in unified PyCharm free mode
 
 ## [0.0.52] - 2025-12-15
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ See [documentation](https://koxudaxi.github.io/ruff-pycharm-plugin/) for more de
 - [x] Detect `ruff` executable in WSL
 - [x] Support Ruff LSP feature
   - LSP Client
-    - [x] [Intellij LSP integration](https://blog.jetbrains.com/platform/2023/07/lsp-for-plugin-developers/) for PyCharm Pro/IDEA Ultimate
+    - [x] [JetBrains LSP integration](https://platform.jetbrains.com/t/update-on-lsp-and-template-language-apis-in-pycharm/1453) for unified PyCharm, including free mode
     - [x] [LSP4IJ by RedHat](https://github.com/redhat-developer/lsp4ij) (Requires installation of the [LSP4IJ plugin](https://plugins.jetbrains.com/plugin/23257-lsp4ij))
   - LSP Server
     - [x] `ruff-lsp` integration
@@ -44,8 +44,11 @@ See [documentation](https://koxudaxi.github.io/ruff-pycharm-plugin/) for more de
   - [x] Live Config Reload: Automatically updates from `pyproject.toml` and `ruff.toml` without restarting
 - [x] Support `ruff format` for ruff version `0.0.289` or later [Experimental]
 
-### Support `ruff-lsp` for only PyCharm Pro/IDEA Ultimate
-You can enable it in `Preferences/Settings` -> `Tools` -> `Ruff` -> `Use ruff-lsp (Experimental) for PyCharm Pro/IDEA Ultimate`
+### JetBrains LSP client support
+In unified PyCharm builds, including free mode, you can enable the JetBrains LSP client in `Preferences/Settings` -> `Tools` -> `Ruff`.
+
+PyCharm made the LSP client APIs available without a paid subscription starting with 2025.1:
+https://platform.jetbrains.com/t/update-on-lsp-and-template-language-apis-in-pycharm/1453
 
 The lsp integration applies only below features:
 - Errors/warnings highlighting ([textDocument/publishDiagnostics](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_publishDiagnostics))

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,7 +37,7 @@ dependencies {
         val version = properties("platformVersion")
         val bundledPlugins =
             properties("platformBundledPlugins").map { it.split(',').map(String::trim).filter(String::isNotEmpty) }
-        pycharmProfessional(version) {
+        pycharm(version) {
             useInstaller.set(false)
         }
         bundledPlugins(bundledPlugins)

--- a/docs/index.md
+++ b/docs/index.md
@@ -54,7 +54,7 @@ See [documentation](https://koxudaxi.github.io/ruff-pycharm-plugin/) for more de
 - [x] Detect `ruff` executable in WSL
 - [x] Support Ruff LSP feature
   - LSP Client
-    - [x] [Intellij LSP integration](https://blog.jetbrains.com/platform/2023/07/lsp-for-plugin-developers/) for PyCharm Pro/IDEA Ultimate
+    - [x] [JetBrains LSP integration](https://platform.jetbrains.com/t/update-on-lsp-and-template-language-apis-in-pycharm/1453) for unified PyCharm, including free mode
     - [x] [LSP4IJ by RedHat](https://github.com/redhat-developer/lsp4ij) (Requires installation of the [LSP4IJ plugin](https://plugins.jetbrains.com/plugin/23257-lsp4ij))
   - LSP Server
     - [x] `ruff-lsp` integration
@@ -62,8 +62,11 @@ See [documentation](https://koxudaxi.github.io/ruff-pycharm-plugin/) for more de
   - [x] Live Config Reload: Automatically updates from `pyproject.toml` and `ruff.toml` without restarting
 - [x] Support `ruff format` for ruff version `0.0.289` or later [Experimental]
 
-### Support `ruff-lsp` for only PyCharm Pro/IDEA Ultimate
-You can enable it in `Preferences/Settings` -> `Tools` -> `Ruff` -> `Use ruff-lsp (Experimental) for PyCharm Pro/IDEA Ultimate`
+### JetBrains LSP client support
+In unified PyCharm builds, including free mode, you can enable the JetBrains LSP client in `Preferences/Settings` -> `Tools` -> `Ruff`.
+
+PyCharm made the LSP client APIs available without a paid subscription starting with 2025.1:
+https://platform.jetbrains.com/t/update-on-lsp-and-template-language-apis-in-pycharm/1453
 
 The lsp integration applies only below features:
 - Errors/warnings highlighting ([textDocument/publishDiagnostics](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_publishDiagnostics))
@@ -80,4 +83,3 @@ We are waiting for your contributions to `ruff-pycharm-plugin`.
 
 ### Other PyCharm plugin projects
 [Pydantic PyCharm Plugin](https://github.com/koxudaxi/pydantic-pycharm-plugin/)
-

--- a/resources/META-INF/only-ultimate.xml
+++ b/resources/META-INF/only-ultimate.xml
@@ -1,5 +1,0 @@
-<idea-plugin>
-    <extensions defaultExtensionNs="com.intellij">
-        <platform.lsp.serverSupportProvider implementation="RuffLspServerSupportProvider"/>
-    </extensions>
-</idea-plugin>

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -8,8 +8,8 @@
     <depends optional="true">PythonCore</depends>
     <depends optional="true">Pythonid</depends>
     <depends optional="true" config-file="only-lsp4ij.xml">com.redhat.devtools.lsp4ij</depends>
-    <depends optional="true" config-file="only-ultimate.xml">com.intellij.modules.ultimate</depends>
     <extensions defaultExtensionNs="com.intellij">
+        <platform.lsp.serverSupportProvider implementation="RuffLspServerSupportProvider"/>
         <notificationGroup id="Ruff Notification Group" displayType="STICKY_BALLOON"/>
         <postStartupActivity implementation="com.koxudaxi.ruff.RuffProjectInitializer"/>
         <projectConfigurable groupId="tools" instance="com.koxudaxi.ruff.RuffConfigurable"/>

--- a/src/com/koxudaxi/ruff/RuffConfigPanel.form
+++ b/src/com/koxudaxi/ruff/RuffConfigPanel.form
@@ -133,7 +133,7 @@
                       <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                     </constraints>
                     <properties>
-                      <text value="Intellij's LSP Client (only pro versions)"/>
+                      <text value="JetBrains LSP Client"/>
                     </properties>
                   </component>
                   <hspacer id="be0d7">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Ruff LSP client support now available for all PyCharm versions, including the free edition, via unified JetBrains LSP integration available in JetBrains IDEs 2025.1+.

* **Documentation**
  * Updated README and documentation with configuration instructions for the new JetBrains LSP client support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->