### PR TITLE
Bump version to 0.0.53

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,16 +2,6 @@
 
 ## [Unreleased]
 
-## [0.0.53] - 2026-04-13
-
-- Fix Ruff settings showing spurious changes and clarify that format-on-save is project-scoped [[#674](https://github.com/koxudaxi/ruff-pycharm-plugin/pull/674)]
-- Fix: centralize Ruff format arguments to preserve `--stdin-filename` handling [[#668](https://github.com/koxudaxi/ruff-pycharm-plugin/pull/668)]
-- Fix native Ruff support notification dismissal to persist per machine [[#667](https://github.com/koxudaxi/ruff-pycharm-plugin/pull/667)]
-- Support 2026.1 [[#671](https://github.com/koxudaxi/ruff-pycharm-plugin/pull/671)]
-- Support formatting Python stub files [[#672](https://github.com/koxudaxi/ruff-pycharm-plugin/pull/672)]
-- Check IntelliJ LSP provider registration before enabling native client [[#675](https://github.com/koxudaxi/ruff-pycharm-plugin/pull/675)]
-- Enable JetBrains LSP client support in unified PyCharm free mode [[#676](https://github.com/koxudaxi/ruff-pycharm-plugin/pull/676)]
-
 ## [0.0.52] - 2025-12-15
 
 - Fix: add --stdin-filename to format command for config auto-discovery [[#651](https://github.com/koxudaxi/ruff-pycharm-plugin/pull/651)]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+- Fix Ruff settings showing spurious changes and clarify that format-on-save is project-scoped [[#674](https://github.com/koxudaxi/ruff-pycharm-plugin/pull/674)]
+- Fix: centralize Ruff format arguments to preserve `--stdin-filename` handling [[#668](https://github.com/koxudaxi/ruff-pycharm-plugin/pull/668)]
+- Fix native Ruff support notification dismissal to persist per machine [[#667](https://github.com/koxudaxi/ruff-pycharm-plugin/pull/667)]
+- Support 2026.1 [[#671](https://github.com/koxudaxi/ruff-pycharm-plugin/pull/671)]
+- Support formatting Python stub files [[#672](https://github.com/koxudaxi/ruff-pycharm-plugin/pull/672)]
+- Check IntelliJ LSP provider registration before enabling native client [[#675](https://github.com/koxudaxi/ruff-pycharm-plugin/pull/675)]
+- Enable JetBrains LSP client support in unified PyCharm free mode [[#676](https://github.com/koxudaxi/ruff-pycharm-plugin/pull/676)]
+
 ## [0.0.52] - 2025-12-15
 
 - Fix: add --stdin-filename to format command for config auto-discovery [[#651](https://github.com/koxudaxi/ruff-pycharm-plugin/pull/651)]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.0.53] - 2026-04-13
+
 - Fix Ruff settings showing spurious changes and clarify that format-on-save is project-scoped [[#674](https://github.com/koxudaxi/ruff-pycharm-plugin/pull/674)]
 - Fix: centralize Ruff format arguments to preserve `--stdin-filename` handling [[#668](https://github.com/koxudaxi/ruff-pycharm-plugin/pull/668)]
 - Fix native Ruff support notification dismissal to persist per machine [[#667](https://github.com/koxudaxi/ruff-pycharm-plugin/pull/667)]

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ pluginGroup = com.koxudaxi.ruff
 pluginName = Ruff
 pluginRepositoryUrl = https://github.com/koxudaxi/ruff-pycharm-plugin
 # SemVer format -> https://semver.org
-pluginVersion = 0.0.52
+pluginVersion = 0.0.53
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 261


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Version bumped to 0.0.53.

* **Documentation**
  * Cleared the "Unreleased" changelog entries so the upcoming release section is empty prior to the last published release.

* **Notes**
  * No functional or public API changes were made.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->