### PR TITLE
Prepare 0.0.55 Python plugin compatibility fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Prepare 0.0.55 Marketplace resubmission of the 0.0.54 changes by loading Python integrations only when the Python plugin is available
+
 ## [0.0.54] - 2026-04-15
 
 - Prepare 0.0.54 Marketplace resubmission of the 0.0.53 changes by removing internal Python package management API usage [[#679](https://github.com/koxudaxi/ruff-pycharm-plugin/pull/679)]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-- Prepare 0.0.55 Marketplace resubmission of the 0.0.54 changes by loading Python integrations only when the Python plugin is available
+- Prepare 0.0.55 Marketplace resubmission of the 0.0.54 changes by loading Python integrations only when the Python plugin is available [[#681](https://github.com/koxudaxi/ruff-pycharm-plugin/pull/681)]
 
 ## [0.0.54] - 2026-04-15
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ pluginGroup = com.koxudaxi.ruff
 pluginName = Ruff
 pluginRepositoryUrl = https://github.com/koxudaxi/ruff-pycharm-plugin
 # SemVer format -> https://semver.org
-pluginVersion = 0.0.54
+pluginVersion = 0.0.55
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 261

--- a/resources/META-INF/only-lsp4ij.xml
+++ b/resources/META-INF/only-lsp4ij.xml
@@ -1,4 +1,5 @@
 <idea-plugin>
+    <depends>PythonCore</depends>
     <depends>com.redhat.devtools.lsp4ij</depends>
     <extensions defaultExtensionNs="com.redhat.devtools.lsp4ij">
         <server id="ruffLanguageServer"

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -6,4 +6,5 @@
     <depends>com.intellij.modules.lang</depends>
     <depends>com.intellij.modules.platform</depends>
     <depends optional="true" config-file="python-core.xml">PythonCore</depends>
+    <depends optional="true" config-file="only-lsp4ij.xml">com.redhat.devtools.lsp4ij</depends>
 </idea-plugin>

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -5,32 +5,5 @@
 
     <depends>com.intellij.modules.lang</depends>
     <depends>com.intellij.modules.platform</depends>
-    <depends optional="true">PythonCore</depends>
-    <depends optional="true">Pythonid</depends>
-    <depends optional="true" config-file="only-lsp4ij.xml">com.redhat.devtools.lsp4ij</depends>
-    <extensions defaultExtensionNs="com.intellij">
-        <platform.lsp.serverSupportProvider implementation="RuffLspServerSupportProvider"/>
-        <notificationGroup id="Ruff Notification Group" displayType="STICKY_BALLOON"/>
-        <postStartupActivity implementation="com.koxudaxi.ruff.RuffProjectInitializer"/>
-        <projectConfigurable groupId="tools" instance="com.koxudaxi.ruff.RuffConfigurable"/>
-        <localInspection language="Python" shortName="RuffInspection" suppressId="Ruff"
-                         displayName="Ruff inspection"
-                         enabledByDefault="true" level="WARNING"
-                         implementationClass="com.koxudaxi.ruff.RuffInspection"/>
-        <externalAnnotator language="Python" implementationClass="com.koxudaxi.ruff.RuffExternalAnnotator"/>
-        <formattingService implementation="com.koxudaxi.ruff.RuffAsyncFormatter" order="first"/>
-        <lang.importOptimizer language="Python" implementationClass="com.koxudaxi.ruff.RuffImportOptimizer" order="first"/>
-        <platform.backend.documentation.targetProvider
-                implementation="com.koxudaxi.ruff.RuffNoqaDocumentationTargetProvider"/>
-        <actionOnSave id="RuffFormatterActionOnSave" implementation="com.koxudaxi.ruff.RuffActionOnSave" order="last"/>
-        <toolWindow factoryClass="com.koxudaxi.ruff.RuffLoggingToolWindowFactory"
-                    id="Ruff Logging"
-                    anchor="bottom"
-                    secondary="true" />
-    </extensions>
-    <actions>
-        <action id="ExecuteRuff" class="com.koxudaxi.ruff.RuffRun" text="Run Ruff"
-                description="Run ruff with fix option">
-        </action>
-    </actions>
+    <depends optional="true" config-file="python-core.xml">PythonCore</depends>
 </idea-plugin>

--- a/resources/META-INF/python-core.xml
+++ b/resources/META-INF/python-core.xml
@@ -1,6 +1,6 @@
 <idea-plugin>
     <extensions defaultExtensionNs="com.intellij">
-        <platform.lsp.serverSupportProvider implementation="RuffLspServerSupportProvider"/>
+        <platform.lsp.serverSupportProvider implementation="com.koxudaxi.ruff.lsp.intellij.RuffLspServerSupportProvider"/>
         <notificationGroup id="Ruff Notification Group" displayType="STICKY_BALLOON"/>
         <postStartupActivity implementation="com.koxudaxi.ruff.RuffProjectInitializer"/>
         <projectConfigurable groupId="tools" instance="com.koxudaxi.ruff.RuffConfigurable"/>

--- a/resources/META-INF/python-core.xml
+++ b/resources/META-INF/python-core.xml
@@ -1,5 +1,4 @@
 <idea-plugin>
-    <depends optional="true" config-file="only-lsp4ij.xml">com.redhat.devtools.lsp4ij</depends>
     <extensions defaultExtensionNs="com.intellij">
         <platform.lsp.serverSupportProvider implementation="RuffLspServerSupportProvider"/>
         <notificationGroup id="Ruff Notification Group" displayType="STICKY_BALLOON"/>

--- a/resources/META-INF/python-core.xml
+++ b/resources/META-INF/python-core.xml
@@ -1,0 +1,28 @@
+<idea-plugin>
+    <depends optional="true" config-file="only-lsp4ij.xml">com.redhat.devtools.lsp4ij</depends>
+    <extensions defaultExtensionNs="com.intellij">
+        <platform.lsp.serverSupportProvider implementation="RuffLspServerSupportProvider"/>
+        <notificationGroup id="Ruff Notification Group" displayType="STICKY_BALLOON"/>
+        <postStartupActivity implementation="com.koxudaxi.ruff.RuffProjectInitializer"/>
+        <projectConfigurable groupId="tools" instance="com.koxudaxi.ruff.RuffConfigurable"/>
+        <localInspection language="Python" shortName="RuffInspection" suppressId="Ruff"
+                         displayName="Ruff inspection"
+                         enabledByDefault="true" level="WARNING"
+                         implementationClass="com.koxudaxi.ruff.RuffInspection"/>
+        <externalAnnotator language="Python" implementationClass="com.koxudaxi.ruff.RuffExternalAnnotator"/>
+        <formattingService implementation="com.koxudaxi.ruff.RuffAsyncFormatter" order="first"/>
+        <lang.importOptimizer language="Python" implementationClass="com.koxudaxi.ruff.RuffImportOptimizer" order="first"/>
+        <platform.backend.documentation.targetProvider
+                implementation="com.koxudaxi.ruff.RuffNoqaDocumentationTargetProvider"/>
+        <actionOnSave id="RuffFormatterActionOnSave" implementation="com.koxudaxi.ruff.RuffActionOnSave" order="last"/>
+        <toolWindow factoryClass="com.koxudaxi.ruff.RuffLoggingToolWindowFactory"
+                    id="Ruff Logging"
+                    anchor="bottom"
+                    secondary="true" />
+    </extensions>
+    <actions>
+        <action id="ExecuteRuff" class="com.koxudaxi.ruff.RuffRun" text="Run Ruff"
+                description="Run ruff with fix option">
+        </action>
+    </actions>
+</idea-plugin>

--- a/src/com/koxudaxi/ruff/Ruff.kt
+++ b/src/com/koxudaxi/ruff/Ruff.kt
@@ -1,6 +1,5 @@
 package com.koxudaxi.ruff
 
-import RuffLspServerSupportProvider
 import com.intellij.codeInspection.ex.InspectionToolRegistrar
 import com.intellij.credentialStore.toByteArrayAndClear
 import com.intellij.execution.ExecutionException
@@ -38,6 +37,7 @@ import com.intellij.psi.PsiFile
 import com.jetbrains.python.packaging.IndicatedProcessOutputListener
 import com.jetbrains.python.packaging.PyCondaPackageService
 import com.jetbrains.python.sdk.*
+import com.koxudaxi.ruff.lsp.intellij.RuffLspServerSupportProvider
 import com.jetbrains.python.target.PyTargetAwareAdditionalData
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json

--- a/src/com/koxudaxi/ruff/Ruff.kt
+++ b/src/com/koxudaxi/ruff/Ruff.kt
@@ -240,7 +240,14 @@ fun detectRuffExecutable(
 val Sdk.isWsl: Boolean get() = (sdkAdditionalData as? PyTargetAwareAdditionalData)?.targetEnvironmentConfiguration is WslTargetEnvironmentConfiguration
 
 private fun Sdk.isCondaSdk(): Boolean =
-    PythonSdkUtil.isConda(this)
+    homePath?.let(::findCondaMetaPath) != null
+
+private fun findCondaMetaPath(sdkPath: String): File? {
+    val homeDirectory = File(sdkPath)
+    val parentDirectory = homeDirectory.parentFile ?: return null
+    val condaParent = if (SystemInfo.isWindows) parentDirectory else parentDirectory.parentFile ?: return null
+    return File(condaParent, "conda-meta").takeIf { it.isDirectory }
+}
 
 fun findRuffExecutableInSDK(sdk: Sdk, lsp: Boolean): File? {
     return when {

--- a/src/com/koxudaxi/ruff/Ruff.kt
+++ b/src/com/koxudaxi/ruff/Ruff.kt
@@ -38,7 +38,6 @@ import com.intellij.psi.PsiFile
 import com.jetbrains.python.packaging.IndicatedProcessOutputListener
 import com.jetbrains.python.packaging.PyCondaPackageService
 import com.jetbrains.python.sdk.*
-import com.jetbrains.python.sdk.flavors.conda.CondaEnvSdkFlavor
 import com.jetbrains.python.target.PyTargetAwareAdditionalData
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
@@ -240,6 +239,10 @@ fun detectRuffExecutable(
 
 val Sdk.isWsl: Boolean get() = (sdkAdditionalData as? PyTargetAwareAdditionalData)?.targetEnvironmentConfiguration is WslTargetEnvironmentConfiguration
 
+private fun Sdk.isCondaSdk(): Boolean =
+    (sdkAdditionalData as? PythonSdkAdditionalData)?.flavor?.javaClass?.name ==
+        "com.jetbrains.python.sdk.flavors.conda.CondaEnvSdkFlavor"
+
 fun findRuffExecutableInSDK(sdk: Sdk, lsp: Boolean): File? {
     return when {
         sdk.wslIsSupported && sdk.isWsl -> {
@@ -251,7 +254,7 @@ fun findRuffExecutableInSDK(sdk: Sdk, lsp: Boolean): File? {
             File(distribution.getWindowsPath(homeParent), getRuffWlsCommand(lsp))
         }
 
-        (sdk.sdkAdditionalData as? PythonSdkAdditionalData)?.flavor is CondaEnvSdkFlavor ->
+        sdk.isCondaSdk() ->
             when {
                 SystemInfo.isWindows -> sdk.homeDirectory?.parent // {python_dir}/python.exe
                 else -> sdk.homeDirectory?.parent?.parent // {python_dir}/bin/python

--- a/src/com/koxudaxi/ruff/Ruff.kt
+++ b/src/com/koxudaxi/ruff/Ruff.kt
@@ -240,8 +240,7 @@ fun detectRuffExecutable(
 val Sdk.isWsl: Boolean get() = (sdkAdditionalData as? PyTargetAwareAdditionalData)?.targetEnvironmentConfiguration is WslTargetEnvironmentConfiguration
 
 private fun Sdk.isCondaSdk(): Boolean =
-    (sdkAdditionalData as? PythonSdkAdditionalData)?.flavor?.javaClass?.name ==
-        "com.jetbrains.python.sdk.flavors.conda.CondaEnvSdkFlavor"
+    PythonSdkUtil.isConda(this)
 
 fun findRuffExecutableInSDK(sdk: Sdk, lsp: Boolean): File? {
     return when {

--- a/src/com/koxudaxi/ruff/RuffConfigPanel.kt
+++ b/src/com/koxudaxi/ruff/RuffConfigPanel.kt
@@ -1,9 +1,7 @@
 package com.koxudaxi.ruff
 
-
-import com.intellij.ide.plugins.PluginManagerConfigurable
+import com.intellij.ide.BrowserUtil
 import com.intellij.openapi.fileChooser.FileChooserDescriptorFactory
-import com.intellij.openapi.options.ShowSettingsUtil
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.TextFieldWithBrowseButton
 import com.intellij.openapi.ui.emptyText
@@ -69,9 +67,7 @@ class RuffConfigPanel(project: Project) {
 
         lsp4ijLinkLabel.addMouseListener(object : MouseAdapter() {
             override fun mouseClicked(e: MouseEvent?) {
-                ShowSettingsUtil.getInstance().showSettingsDialog(
-                    project, PluginManagerConfigurable::class.java,
-                    { c -> c.openMarketplaceTab("com.redhat.devtools.lsp4ij") })
+                BrowserUtil.browse("https://plugins.jetbrains.com/plugin/23257-lsp4ij")
             }
         })
         runRuffOnSaveCheckBox.addActionListener {

--- a/src/com/koxudaxi/ruff/RuffConfigurable.kt
+++ b/src/com/koxudaxi/ruff/RuffConfigurable.kt
@@ -1,11 +1,11 @@
 package com.koxudaxi.ruff
 
-import RuffLspServerSupportProvider
 import com.intellij.execution.ui.ConsoleViewContentType
 import com.intellij.openapi.options.Configurable
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.wm.ToolWindowManager
 import com.koxudaxi.ruff.lsp.ClientType
+import com.koxudaxi.ruff.lsp.intellij.RuffLspServerSupportProvider
 import com.koxudaxi.ruff.lsp.lsp4ij.RuffLsp4IntellijClient
 import java.io.File
 import javax.swing.JComponent

--- a/src/com/koxudaxi/ruff/RuffNoqaDocumentationTarget.kt
+++ b/src/com/koxudaxi/ruff/RuffNoqaDocumentationTarget.kt
@@ -1,6 +1,5 @@
 package com.koxudaxi.ruff
 
-import com.intellij.codeInsight.navigation.targetPresentation
 import com.intellij.markdown.utils.doc.DocMarkdownToHtmlConverter
 import com.intellij.model.Pointer
 import com.intellij.openapi.application.ApplicationManager
@@ -16,7 +15,9 @@ import com.intellij.psi.util.startOffset
 class RuffNoqaDocumentationTarget(private val psiComment: PsiComment, private val originalElement: PsiComment?, private val offset: Int): DocumentationTarget {
     @Suppress("UnstableApiUsage")
     override fun computePresentation(): TargetPresentation {
-        return targetPresentation(psiComment)
+        return TargetPresentation.builder(psiComment.text)
+            .icon(psiComment.getIcon(0))
+            .presentation()
     }
 
     private val replaceHtmlTags = listOf(
@@ -62,4 +63,5 @@ class RuffNoqaDocumentationTarget(private val psiComment: PsiComment, private va
         val startPart = psiComment.text.substring(0, targetOffset).takeLastWhile { it.isLetterOrDigit() }
         val endPart = psiComment.text.substring(targetOffset).takeWhile { it.isLetterOrDigit() }
         return startPart + endPart
-    }}
+    }
+}

--- a/src/com/koxudaxi/ruff/RuffProjectInitializer.kt
+++ b/src/com/koxudaxi/ruff/RuffProjectInitializer.kt
@@ -32,6 +32,7 @@ class RuffProjectInitializer : ProjectActivity {
         if (hasPyPackageManagerApi()) {
             subscribeToPackageManagerChanges(project)
         } else {
+            project.preferredPythonSdk?.let { refreshRuffExecutableFromSdk(project, it) }
             RuffLoggingService.log(project, "PyPackageManager API is unavailable; skipping package manager subscription")
         }
 

--- a/src/com/koxudaxi/ruff/RuffProjectInitializer.kt
+++ b/src/com/koxudaxi/ruff/RuffProjectInitializer.kt
@@ -29,7 +29,11 @@ class RuffProjectInitializer : ProjectActivity {
         if (ApplicationManager.getApplication().isUnitTestMode) return
         if (project.isDisposed) return
 
-        subscribeToPackageManagerChanges(project)
+        if (hasPyPackageManagerApi()) {
+            subscribeToPackageManagerChanges(project)
+        } else {
+            RuffLoggingService.log(project, "PyPackageManager API is unavailable; skipping package manager subscription")
+        }
 
         DumbService.getInstance(project).smartInvokeLater {
             checkAndNotifyNativeRuffSupport(project)
@@ -65,6 +69,16 @@ class RuffProjectInitializer : ProjectActivity {
             }
         }
     }
+
+    private fun hasPyPackageManagerApi(): Boolean =
+        try {
+            Class.forName("com.jetbrains.python.packaging.PyPackageManager", false, javaClass.classLoader)
+            true
+        } catch (_: ClassNotFoundException) {
+            false
+        } catch (_: NoClassDefFoundError) {
+            false
+        }
 
     private fun setUpPyProjectTomlLister(project: Project) {
         VirtualFileManager.getInstance().addAsyncFileListener(

--- a/src/com/koxudaxi/ruff/lsp/intellij/RuffIntellijLspClient.kt
+++ b/src/com/koxudaxi/ruff/lsp/intellij/RuffIntellijLspClient.kt
@@ -1,6 +1,4 @@
 package com.koxudaxi.ruff.lsp.intellij
-
-import RuffLspServerSupportProvider
 import com.intellij.openapi.project.Project
 import com.intellij.platform.lsp.api.LspServerManager
 import com.koxudaxi.ruff.RuffLoggingService

--- a/src/com/koxudaxi/ruff/lsp/intellij/RuffLspServerSupportProvider.kt
+++ b/src/com/koxudaxi/ruff/lsp/intellij/RuffLspServerSupportProvider.kt
@@ -1,3 +1,5 @@
+package com.koxudaxi.ruff.lsp.intellij
+
 import com.intellij.execution.configurations.GeneralCommandLine
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile

--- a/testSrc/RuffLspServerSupportProviderTest.kt
+++ b/testSrc/RuffLspServerSupportProviderTest.kt
@@ -1,6 +1,7 @@
 import com.intellij.execution.configurations.GeneralCommandLine
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
 import com.koxudaxi.ruff.RuffConfigService
+import com.koxudaxi.ruff.lsp.intellij.RuffLspServerDescriptorBase
 import kotlin.io.path.createTempFile
 
 class RuffLspServerSupportProviderTest : BasePlatformTestCase() {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped version to 0.0.55 for marketplace resubmission
  * Python integrations reorganized and conditionally loaded when the Python support is present

* **Bug Fixes**
  * Conditional loading of Ruff features based on Python plugin availability
  * Improved detection of Conda-based Python environments

* **Documentation**
  * Plugin reference link updated to open the marketplace page in a browser
<!-- end of auto-generated comment: release notes by coderabbit.ai -->